### PR TITLE
Fix typo (attribute_labels)

### DIFF
--- a/exporter/qrynexporter/config.go
+++ b/exporter/qrynexporter/config.go
@@ -53,8 +53,8 @@ type QueueSettings struct {
 
 // LogsConfig holds the configuration for log data.
 type LogsConfig struct {
-	// AttritubeLabels is the string representing attribute labels.
-	AttritubeLabels string `mapstructure:"attritube_labels"`
+	// AttributeLabels is the string representing attribute labels.
+	AttributeLabels string `mapstructure:"attribute_labels"`
 	// ResourceLabels is the string representing resource labels.
 	ResourceLabels string `mapstructure:"resource_labels"`
 	// Format is the string representing the format.

--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -33,7 +33,7 @@ type logsExporter struct {
 
 	db clickhouse.Conn
 
-	attritubeLabels string
+	attributeLabels string
 	resourceLabels  string
 	format          string
 	cluster         bool
@@ -52,7 +52,7 @@ func newLogsExporter(logger *zap.Logger, cfg *Config) (*logsExporter, error) {
 		logger:          logger,
 		db:              db,
 		format:          cfg.Logs.Format,
-		attritubeLabels: cfg.Logs.AttritubeLabels,
+		attributeLabels: cfg.Logs.AttributeLabels,
 		resourceLabels:  cfg.Logs.ResourceLabels,
 		cluster:         cfg.ClusteredClickhouse,
 	}, nil
@@ -107,13 +107,13 @@ func (e *logsExporter) convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs 
 		out = out.Merge(labels)
 	}
 
-	if e.attritubeLabels != "" {
+	if e.attributeLabels != "" {
 		labels := convertSelectedAttributesToLabels(logAttrs, pcommon.NewValueStr(e.resourceLabels))
 		out = out.Merge(labels)
 	}
 
 	if e.resourceLabels != "" {
-		labels := convertSelectedAttributesToLabels(resAttrs, pcommon.NewValueStr(e.attritubeLabels))
+		labels := convertSelectedAttributesToLabels(resAttrs, pcommon.NewValueStr(e.attributeLabels))
 		out = out.Merge(labels)
 	}
 


### PR DESCRIPTION
This PR fixes a typo with the logs config: `attritube_labels` --> `attribute_labels`.