### PR TITLE
Add an info message when pushing logs and metrics

### DIFF
--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -436,7 +436,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 		return err
 	}
 
-	e.logger.Info("pushLogsData", zap.Int("samples", len(samples)), zap.Int("timeseries", len(timeSeries)), zap.String("cost", time.Since(start).String()))
+	e.logger.Debug("pushLogsData", zap.Int("samples", len(samples)), zap.Int("timeseries", len(timeSeries)), zap.String("cost", time.Since(start).String()))
 
 	return nil
 }

--- a/exporter/qrynexporter/metrics.go
+++ b/exporter/qrynexporter/metrics.go
@@ -486,7 +486,7 @@ func (e *metricsExporter) pushMetricsData(ctx context.Context, md pmetric.Metric
 		return err
 	}
 
-	e.logger.Info("pushMetricsData", zap.Int("samples", len(samples)), zap.Int("timeseries", len(timeSeries)), zap.String("cost", time.Since(start).String()))
+	e.logger.Debug("pushMetricsData", zap.Int("samples", len(samples)), zap.Int("timeseries", len(timeSeries)), zap.String("cost", time.Since(start).String()))
 
 	return nil
 }

--- a/exporter/qrynexporter/traces.go
+++ b/exporter/qrynexporter/traces.go
@@ -185,7 +185,7 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 	if err := e.exportResourceSapns(_ctx, td.ResourceSpans()); err != nil {
 		return err
 	}
-	e.logger.Info("pushTraceData", zap.Int("spanCount", td.SpanCount()), zap.String("cost", time.Since(start).String()))
+	e.logger.Debug("pushTraceData", zap.Int("spanCount", td.SpanCount()), zap.String("cost", time.Since(start).String()))
 	return nil
 }
 


### PR DESCRIPTION
These changes add logging information for `logs` and `metrics` in a similar manner to what already exists for traces.