### PR TITLE
refactor: improve the code structure and documentation of qrynexporter.

### DIFF
--- a/exporter/qrynexporter/README.md
+++ b/exporter/qrynexporter/README.md
@@ -20,13 +20,6 @@
   - Default: `true`
   - Description: Enables client-side processing of trace data. This can improve performance but may increase client-side resource usage.
 
-<<<<<<< HEAD
-- `dsn` (required): Clickhouse's dsn.
-- `clustered_clickhouse` (required): true if clickhouse cluster is used
-- `client_side_trace_processing`: use improved traces ingestion algorythm for clickhouse clusters. 
-Data ingestion is sess performant but more evenly distributed 
-=======
->>>>>>> e35202d (refactor: improve the code structure and documentation of qrynexporter.)
 
 # Example:
 ## Simple Trace Data

--- a/exporter/qrynexporter/README.md
+++ b/exporter/qrynexporter/README.md
@@ -8,11 +8,25 @@
 
 
 # Configuration options:
+- `dsn` (required): Data Source Name for Clickhouse.
+  - Example: `tcp://localhost:9000/?database=cloki`
 
+- `clustered_clickhouse` (required): 
+  - Type: boolean
+  - Description: Set to `true` if using a Clickhouse cluster; otherwise, set to `false`.
+
+- `client_side_trace_processing` (required):
+  - Type: boolean
+  - Default: `true`
+  - Description: Enables client-side processing of trace data. This can improve performance but may increase client-side resource usage.
+
+<<<<<<< HEAD
 - `dsn` (required): Clickhouse's dsn.
 - `clustered_clickhouse` (required): true if clickhouse cluster is used
 - `client_side_trace_processing`: use improved traces ingestion algorythm for clickhouse clusters. 
 Data ingestion is sess performant but more evenly distributed 
+=======
+>>>>>>> e35202d (refactor: improve the code structure and documentation of qrynexporter.)
 
 # Example:
 ## Simple Trace Data

--- a/exporter/qrynexporter/README.md
+++ b/exporter/qrynexporter/README.md
@@ -9,7 +9,7 @@
 
 # Configuration options:
 - `dsn` (required): Data Source Name for Clickhouse.
-  - Example: `tcp://localhost:9000/?database=cloki`
+  - Example: `tcp://localhost:9000/qryn`
 
 - `clustered_clickhouse` (required): 
   - Type: boolean

--- a/exporter/qrynexporter/config.go
+++ b/exporter/qrynexporter/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	configretry.BackOffConfig      `mapstructure:"retry_on_failure"`
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 
+<<<<<<< HEAD
+=======
+	// ClientSideTraceProcessing is a boolean that indicates whether to process traces on the client side.
+>>>>>>> e35202d (refactor: improve the code structure and documentation of qrynexporter.)
 	ClientSideTraceProcessing bool `mapstructure:"client_side_trace_processing"`
 
 	ClusteredClickhouse bool `mapstructure:"clustered_clickhouse"`

--- a/exporter/qrynexporter/config.go
+++ b/exporter/qrynexporter/config.go
@@ -30,10 +30,7 @@ type Config struct {
 	configretry.BackOffConfig      `mapstructure:"retry_on_failure"`
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 
-<<<<<<< HEAD
-=======
 	// ClientSideTraceProcessing is a boolean that indicates whether to process traces on the client side.
->>>>>>> e35202d (refactor: improve the code structure and documentation of qrynexporter.)
 	ClientSideTraceProcessing bool `mapstructure:"client_side_trace_processing"`
 
 	ClusteredClickhouse bool `mapstructure:"clustered_clickhouse"`

--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -441,7 +441,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 		}
 	}
 
-	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, "cluster", e.cluster), e.db, samples, timeSeries); err != nil {
+	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.db, samples, timeSeries); err != nil {
 		otelcolExporterQrynBatchInsertDurationMillis.Record(ctx, time.Now().UnixMilli()-start.UnixMilli(), metric.WithAttributeSet(*newOtelcolAttrSetBatch(errorCodeError, dataTypeLogs)))
 		e.logger.Error(fmt.Sprintf("failed to insert batch: [%s]", err.Error()))
 		return err

--- a/exporter/qrynexporter/metrics.go
+++ b/exporter/qrynexporter/metrics.go
@@ -491,7 +491,7 @@ func (e *metricsExporter) pushMetricsData(ctx context.Context, md pmetric.Metric
 		}
 	}
 
-	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, "cluster", e.cluster), e.db, samples, timeSeries); err != nil {
+	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.db, samples, timeSeries); err != nil {
 		otelcolExporterQrynBatchInsertDurationMillis.Record(ctx, time.Now().UnixMilli()-start.UnixMilli(), metric.WithAttributeSet(*newOtelcolAttrSetBatch(errorCodeError, dataTypeMetrics)))
 		e.logger.Error(fmt.Sprintf("failed to insert batch: [%s]", err.Error()))
 		return err

--- a/exporter/qrynexporter/schema.go
+++ b/exporter/qrynexporter/schema.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	tracesInputSQL = func(clustered bool) string {
+	tracesInputSQL = func(_ bool) string {
 		return `INSERT INTO traces_input (
   trace_id, 
   span_id, 
@@ -110,8 +110,8 @@ func TracesTagsV2InputSQL(clustered bool) string {
 //
 // ) Engine=Null
 
-// Trace represent trace model
-type Trace struct {
+// TraceInput represent trace model
+type TraceInput struct {
 	TraceID     string     `ch:"trace_id"`
 	SpanID      string     `ch:"span_id"`
 	ParentID    string     `ch:"parent_id"`
@@ -124,7 +124,7 @@ type Trace struct {
 	Tags        [][]string `ch:"tags"`
 }
 
-type TraceV2 struct {
+type TempoTrace struct {
 	OID         string `ch:"oid"`
 	TraceID     []byte `ch:"trace_id"`
 	SpanID      []byte `ch:"span_id"`
@@ -137,7 +137,7 @@ type TraceV2 struct {
 	Payload     string `ch:"payload"`
 }
 
-type TraceTagsV2 struct {
+type TempoTraceTag struct {
 	OID         string    `ch:"oid"`
 	Date        time.Time `ch:"date"`
 	Key         string    `ch:"key"`

--- a/exporter/qrynexporter/trace_batch_processor.go
+++ b/exporter/qrynexporter/trace_batch_processor.go
@@ -3,60 +3,61 @@ package qrynexporter
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
-type batchV2 struct {
+type traceWithTagsBatch struct {
 	driver.Batch
-	subBatch driver.Batch
+	tagsBatch driver.Batch
 }
 
-func (b *batchV2) AppendStruct(data any) error {
-	_data, ok := data.(*Trace)
+func (b *traceWithTagsBatch) AppendStruct(v any) error {
+	ti, ok := v.(*TraceInput)
 	if !ok {
-		return fmt.Errorf("invalid data type, expected *Trace, got %T", data)
+		return fmt.Errorf("invalid data type, expected *Trace, got %T", v)
 	}
-	binTraceId, err := unhexAndPad(_data.TraceID, 16)
+	binTraceId, err := unhexAndPad(ti.TraceID, 16)
 	if err != nil {
 		return err
 	}
-	binParentID, err := unhexAndPad(_data.ParentID, 8)
+	binParentID, err := unhexAndPad(ti.ParentID, 8)
 	if err != nil {
 		return err
 	}
-	binSpanID, err := unhexAndPad(_data.SpanID, 8)
+	binSpanID, err := unhexAndPad(ti.SpanID, 8)
 	if err != nil {
 		return err
 	}
-	trace := &TraceV2{
+	trace := &TempoTrace{
 		OID:         "0",
 		TraceID:     binTraceId,
 		SpanID:      binSpanID,
 		ParentID:    binParentID,
-		Name:        _data.Name,
-		TimestampNs: _data.TimestampNs,
-		DurationNs:  _data.DurationNs,
-		ServiceName: _data.ServiceName,
-		PayloadType: _data.PayloadType,
-		Payload:     _data.Payload,
+		Name:        ti.Name,
+		TimestampNs: ti.TimestampNs,
+		DurationNs:  ti.DurationNs,
+		ServiceName: ti.ServiceName,
+		PayloadType: ti.PayloadType,
+		Payload:     ti.Payload,
 	}
 	err = b.Batch.AppendStruct(trace)
 	if err != nil {
 		return err
 	}
-	for _, tag := range _data.Tags {
-		attr := &TraceTagsV2{
+	for _, tag := range ti.Tags {
+		attr := &TempoTraceTag{
 			OID:         "0",
 			Date:        time.Unix(0, trace.TimestampNs).Truncate(time.Hour * 24),
 			Key:         tag[0],
 			Val:         tag[1],
 			TraceID:     binTraceId,
 			SpanID:      binSpanID,
-			TimestampNs: _data.TimestampNs,
-			DurationNs:  _data.DurationNs,
+			TimestampNs: ti.TimestampNs,
+			DurationNs:  ti.DurationNs,
 		}
-		err = b.subBatch.AppendStruct(attr)
+		err = b.tagsBatch.AppendStruct(attr)
 		if err != nil {
 			return err
 		}
@@ -64,10 +65,10 @@ func (b *batchV2) AppendStruct(data any) error {
 	return nil
 }
 
-func (b *batchV2) Abort() error {
+func (b *traceWithTagsBatch) Abort() error {
 	var errs [2]error
 	errs[0] = b.Batch.Abort()
-	errs[1] = b.subBatch.Abort()
+	errs[1] = b.tagsBatch.Abort()
 	for _, err := range errs {
 		if err != nil {
 			return err
@@ -76,10 +77,10 @@ func (b *batchV2) Abort() error {
 	return nil
 }
 
-func (b *batchV2) Send() error {
+func (b *traceWithTagsBatch) Send() error {
 	var errs [2]error
 	errs[0] = b.Batch.Send()
-	errs[1] = b.subBatch.Send()
+	errs[1] = b.tagsBatch.Send()
 	for _, err := range errs {
 		if err != nil {
 			return err

--- a/exporter/qrynexporter/traces.go
+++ b/exporter/qrynexporter/traces.go
@@ -67,19 +67,11 @@ func newTracesExporter(logger *zap.Logger, cfg *Config, set *exporter.Settings) 
 		return nil, err
 	}
 	exp := &tracesExporter{
-<<<<<<< HEAD
-		logger:  logger,
-		meter:   set.MeterProvider.Meter(typeStr),
-		db:      db,
-		cluster: cfg.ClusteredClickhouse,
-		v2:      cfg.ClusteredClickhouse && cfg.ClientSideTraceProcessing,
-=======
 		logger:     logger,
 		meter:      set.MeterProvider.Meter(typeStr),
 		db:         db,
 		cluster:    cfg.ClusteredClickhouse,
 		clientSide: cfg.ClientSideTraceProcessing,
->>>>>>> e35202d (refactor: improve the code structure and documentation of qrynexporter.)
 	}
 	if err := initMetrics(exp.meter); err != nil {
 		exp.logger.Error(fmt.Sprintf("failed to init metrics: %s", err.Error()))

--- a/exporter/qrynexporter/traces.go
+++ b/exporter/qrynexporter/traces.go
@@ -71,7 +71,7 @@ func newTracesExporter(logger *zap.Logger, cfg *Config, set *exporter.Settings) 
 		meter:      set.MeterProvider.Meter(typeStr),
 		db:         db,
 		cluster:    cfg.ClusteredClickhouse,
-		clientSide: cfg.ClientSideTraceProcessing,
+		clientSide: cfg.ClusteredClickhouse && cfg.ClientSideTraceProcessing,
 	}
 	if err := initMetrics(exp.meter); err != nil {
 		exp.logger.Error(fmt.Sprintf("failed to init metrics: %s", err.Error()))


### PR DESCRIPTION
- rename traces_distributed_export_v2 to client_side_trace_processing
- rename the batchV2 struct to traceWithTagsBatch to improve code readability.
- update the names of struct fields to make them more descriptive.
- rename the traces_v2.go file to trace_batch_processor.go.
- use a custom contextKey type in the pushTraceData function to resolve the SA1029 warning.
- optimize README.md to provide more detailed configuration instructions and examples.
