### PR TITLE
Fix multi arch build action

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -5,10 +5,10 @@ on:
       - main
     paths-ignore:
       - '**.md'
-      
+
 env:
   REGISTRY: ghcr.io
-      
+
 jobs:
   tag_bump:
     runs-on: ubuntu-latest
@@ -24,32 +24,23 @@ jobs:
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: main
           PRERELEASE: true
+
   build:
     needs: tag_bump
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        platform: [ amd64, arm64 ]
-        include:
-          - platform: amd64
-            runner: ubuntu-latest
-          - platform: arm64
-            runner: ARM64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - id: platform_suffix
-        run: |
-          if [ "${{ matrix.platform }}" == "arm64" ]; then
-            echo "PLATFORM_SUFFIX=-arm64" >> $GITHUB_ENV
-          else
-            echo "PLATFORM_SUFFIX=" >> $GITHUB_ENV
-          fi
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4.1.1
@@ -59,11 +50,13 @@ jobs:
           tags: |
             latest
             ${{ needs.tag_bump.outputs.new_tag }}
-      - name: Build and push
-        uses: docker/build-push-action@v3.2.0
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./cmd/otel-collector/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
As the action is right now, it only pushes to the ghrc the last arch in the matrix - arm64.
I took the example from Docker to make it build for multi architectures: https://docs.docker.com/build/ci/github-actions/multi-platform/