### PR TITLE
fix: preserve OTLP resource and log attrs as Loki stream labels (#134)

### DIFF
--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -75,13 +75,22 @@ func (e *logsExporter) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func hasLokiHint(attrs pcommon.Map) bool {
-	for _, hint := range []string{hintAttributes, hintResources, hintTenant} {
-		if _, ok := attrs.Get(hint); ok {
-			return true
-		}
+func hasResourceLabelsHint(logAttrs, resAttrs pcommon.Map) bool {
+	_, found := resAttrs.Get(hintResources)
+	if found {
+		return true
 	}
-	return false
+	_, found = logAttrs.Get(hintResources)
+	return found
+}
+
+func hasAttributeLabelsHint(logAttrs pcommon.Map) bool {
+	_, found := logAttrs.Get(hintAttributes)
+	return found
+}
+
+func isLokiHintKey(k string) bool {
+	return k == hintAttributes || k == hintResources || k == hintTenant || k == hintFormat
 }
 
 func (e *logsExporter) convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model.LabelSet {
@@ -117,19 +126,21 @@ func (e *logsExporter) convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs 
 	}
 
 	if e.attributeLabels != "" {
-		labels := convertSelectedAttributesToLabels(logAttrs, pcommon.NewValueStr(e.resourceLabels))
+		labels := convertSelectedAttributesToLabels(logAttrs, pcommon.NewValueStr(e.attributeLabels))
 		out = out.Merge(labels)
 	}
 
 	if e.resourceLabels != "" {
-		labels := convertSelectedAttributesToLabels(resAttrs, pcommon.NewValueStr(e.attributeLabels))
+		labels := convertSelectedAttributesToLabels(resAttrs, pcommon.NewValueStr(e.resourceLabels))
 		out = out.Merge(labels)
 	}
 
-	// if no any hint found, just mergedLabels
-	if !hasLokiHint(logAttrs) && !hasLokiHint(resAttrs) {
-		out = out.Merge(convertAttributesToLabels(logAttrs))
+	// Hints opt in to specific labels; unset hints keep the default of exporting all attrs.
+	if !hasResourceLabelsHint(logAttrs, resAttrs) {
 		out = out.Merge(convertAttributesToLabels(resAttrs))
+	}
+	if !hasAttributeLabelsHint(logAttrs) {
+		out = out.Merge(convertAttributesToLabels(logAttrs))
 	}
 	return out
 }
@@ -489,6 +500,9 @@ func convertAttributesToLabels(attributes pcommon.Map) model.LabelSet {
 	ls := model.LabelSet{}
 
 	attributes.Range(func(k string, v pcommon.Value) bool {
+		if isLokiHintKey(k) {
+			return true
+		}
 		ls[model.LabelName(k)] = model.LabelValue(v.AsString())
 		return true
 	})
@@ -500,10 +514,14 @@ func addLogLevelAttributeAndHint(log plog.LogRecord) {
 	if log.SeverityNumber() == plog.SeverityNumberUnspecified {
 		return
 	}
-	addLogLevelHit(log)
 	if _, found := log.Attributes().Get(levelAttributeName); !found {
 		level := severityNumberToLevel[log.SeverityNumber().String()]
 		log.Attributes().PutStr(levelAttributeName, level)
+	}
+	// Only extend an existing sender hint; do not inject loki.attribute.labels=level
+	// or resource attrs would be excluded from the default label merge.
+	if _, found := log.Attributes().Get(hintAttributes); found {
+		addLogLevelHit(log)
 	}
 }
 

--- a/exporter/qrynexporter/logs_test.go
+++ b/exporter/qrynexporter/logs_test.go
@@ -1,0 +1,110 @@
+package qrynexporter
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestConvertAttributesAndMerge_DefaultIncludesAllAttrs(t *testing.T) {
+	exp := &logsExporter{}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+	logAttrs.PutStr("k8s.event.reason", "Unhealthy")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+	resAttrs.PutStr("k8s.object.kind", "Pod")
+
+	addLogLevelAttributeAndHint(newLogRecord(plog.SeverityNumberWarn))
+
+	// Re-copy attrs after addLogLevelAttributeAndHint for a realistic flow.
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	assert.Equal(t, model.LabelValue("WARN"), labels["level"])
+	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
+	assert.Equal(t, model.LabelValue("Unhealthy"), labels["k8s.event.reason"])
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+	assert.Equal(t, model.LabelValue("Pod"), labels["k8s.object.kind"])
+}
+
+func TestConvertAttributesAndMerge_RespectsResourceLabelsHint(t *testing.T) {
+	exp := &logsExporter{}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+	resAttrs.PutStr("k8s.object.kind", "Pod")
+	resAttrs.PutStr(hintResources, "signoz.component")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+	assert.NotContains(t, labels, "k8s.object.kind")
+	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
+}
+
+func TestConvertAttributesAndMerge_RespectsAttributeLabelsHint(t *testing.T) {
+	exp := &logsExporter{}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+	logAttrs.PutStr("k8s.event.reason", "Unhealthy")
+	logAttrs.PutStr(hintAttributes, "k8s.event.reason")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	assert.Equal(t, model.LabelValue("Unhealthy"), labels["k8s.event.reason"])
+	assert.NotContains(t, labels, "k8s.namespace.name")
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+}
+
+func TestAddLogLevelAttributeAndHint_AppendsToExistingHint(t *testing.T) {
+	log := newLogRecord(plog.SeverityNumberWarn)
+	log.Attributes().PutStr(hintAttributes, "k8s.event.reason")
+
+	addLogLevelAttributeAndHint(log)
+
+	hint, found := log.Attributes().Get(hintAttributes)
+	require.True(t, found)
+	assert.Equal(t, "k8s.event.reason,level", hint.AsString())
+	assert.Equal(t, "WARN", log.Attributes().AsRaw()["level"])
+}
+
+func TestAddLogLevelAttributeAndHint_DoesNotInjectHint(t *testing.T) {
+	log := newLogRecord(plog.SeverityNumberWarn)
+
+	addLogLevelAttributeAndHint(log)
+
+	_, found := log.Attributes().Get(hintAttributes)
+	assert.False(t, found)
+	assert.Equal(t, "WARN", log.Attributes().AsRaw()["level"])
+}
+
+func newLogRecord(severity plog.SeverityNumber) plog.LogRecord {
+	log := plog.NewLogRecord()
+	log.SetSeverityNumber(severity)
+	return log
+}


### PR DESCRIPTION
### Issue
Fixes #134 
OTLP logs (notably from `k8seventsreceiver`) were indexed in Loki/ClickHouse with only `level` as a stream label.
Resource attributes (`signoz.component`, `k8s.object.*`) and log attributes (`k8s.event.*`, `k8s.namespace.name`) were dropped even though they were present in the OTLP payload.

### Root cause
`addLogLevelAttributeAndHint` always set `loki.attribute.labels=level`. Label merge treated any Loki hint as “hints only” and skipped the default path that exports all attributes. Resource and non-level log attributes were never promoted to stream labels unless explicitly listed in a hint.

Added Tests as well