### PR TITLE
feat(qrynexporter): let logs label config opt out of promote-all default

### DIFF
--- a/exporter/qrynexporter/README.md
+++ b/exporter/qrynexporter/README.md
@@ -27,6 +27,11 @@
   - Description: Specifies the format of trace data sent to ClickHouse. Please use `json` for compatibility with qryn up to 3.2.39. 
 For "Gigapipe" readers please use `proto`.
 
+- `logs` (optional): controls how log attributes become stream labels. See [Logs: attributes vs. labels](docs/logs-labels.md).
+  - `logs.attribute_labels` (optional, string): comma-separated **log-record** attribute names to promote to labels.
+  - `logs.resource_labels` (optional, string): comma-separated **resource** attribute names to promote to labels.
+  - `logs.format` (optional, string): body format (`raw`, `json`, `logfmt`).
+
 
 # Example:
 ## Simple Trace Data

--- a/exporter/qrynexporter/README.md
+++ b/exporter/qrynexporter/README.md
@@ -30,6 +30,7 @@ For "Gigapipe" readers please use `proto`.
 - `logs` (optional): controls how log attributes become stream labels. See [Logs: attributes vs. labels](docs/logs-labels.md).
   - `logs.attribute_labels` (optional, string): comma-separated **log-record** attribute names to promote to labels.
   - `logs.resource_labels` (optional, string): comma-separated **resource** attribute names to promote to labels.
+  - `logs.promote_all_attributes` (optional, bool, default `false`): when `true`, promote **every** log-record attribute to a label. Leave `false` to avoid unbounded label cardinality; only `level` and the attributes you name are promoted.
   - `logs.format` (optional, string): body format (`raw`, `json`, `logfmt`).
 
 

--- a/exporter/qrynexporter/config.go
+++ b/exporter/qrynexporter/config.go
@@ -60,6 +60,13 @@ type LogsConfig struct {
 	ResourceLabels string `mapstructure:"resource_labels"`
 	// Format is the string representing the format.
 	Format string `mapstructure:"format"`
+	// PromoteAllAttributes controls the default promotion of log-record
+	// attributes to stream labels. When false (default), only the level
+	// label plus attributes named via attribute_labels or the
+	// loki.attribute.labels hint are promoted, keeping label cardinality
+	// bounded. When true, every log-record attribute becomes a label.
+	// Resource attributes are unaffected by this flag.
+	PromoteAllAttributes bool `mapstructure:"promote_all_attributes"`
 }
 
 // MetricsConfig holds the configuration for metric data.

--- a/exporter/qrynexporter/docs/logs-labels.md
+++ b/exporter/qrynexporter/docs/logs-labels.md
@@ -1,0 +1,49 @@
+# Logs: attributes vs. labels
+
+How the qryn exporter turns OTLP log attributes into qryn/Loki stream labels, and how to control it.
+
+## Attributes vs. labels
+
+An OTLP log carries two attribute bags:
+
+- **Resource attributes** describe the *source* (e.g. `service.name`, `k8s.namespace.name`, `signoz.component`). One set per batch, stable, low-cardinality.
+- **Log-record attributes** describe the *individual event* (e.g. `k8s.event.reason`, `http.status_code`). Per-record, can vary on every line.
+
+A **label** is different from an attribute: labels form the **stream identity** in qryn/Loki. Every unique combination of label values is a separate stream with its own index entry. Attributes stay in the log payload; only *promoted* attributes become labels. Promoting a high-cardinality attribute (e.g. an event message or an id) to a label creates many streams and slows queries — the classic Loki cardinality anti-pattern.
+
+The `level` label is always derived from the log's severity and promoted automatically.
+
+## How to control which attributes become labels
+
+Two ways, checked independently for resource attrs and for log-record attrs.
+
+1. **Exporter config** (applies to every log in the pipeline):
+
+   ```yaml
+   exporters:
+     qryn:
+       dsn: tcp://localhost:9000/?database=cloki
+       clustered_clickhouse: false
+       logs:
+         resource_labels: "service.name,k8s.namespace.name"   # only these resource attrs → labels
+         attribute_labels: "k8s.event.reason"                  # only these log attrs → labels
+   ```
+
+2. **Per-payload hints** (set by the sender as attributes on the log/resource):
+   - `loki.resource.labels` — comma list of resource attributes to promote.
+   - `loki.attribute.labels` — comma list of log-record attributes to promote.
+   - `loki.tenant` — names the attribute whose value routes the log to a tenant (this is **not** a label).
+   - `loki.format` — output body format.
+
+## Default behaviour
+
+For each bag, **if you name nothing** (no config key and no hint for that bag), the exporter promotes **all** attributes in that bag to labels. As soon as you set the config key **or** the matching hint for a bag, only the names you listed are promoted — that is your opt-out of the all-attributes default.
+
+| Resource attrs → labels | Log attrs → labels | How |
+| --- | --- | --- |
+| all (default) | all (default) | set nothing |
+| only listed | all (default) | set `resource_labels` or `loki.resource.labels` |
+| all (default) | only listed | set `attribute_labels` or `loki.attribute.labels` |
+| only listed | only listed | set both |
+
+> **Cardinality tip:** resource attributes are safe to promote broadly. Log-record attributes are per-event and can be high-cardinality — prefer naming the specific ones you need via `attribute_labels` (or `loki.attribute.labels`) rather than relying on the promote-all default in high-volume pipelines.

--- a/exporter/qrynexporter/docs/logs-labels.md
+++ b/exporter/qrynexporter/docs/logs-labels.md
@@ -1,6 +1,6 @@
 # Logs: attributes vs. labels
 
-How the qryn exporter turns OTLP log attributes into qryn/Loki stream labels, and how to control it.
+How the Gigapipe exporter turns OTLP log attributes into Gigapipe/Loki stream labels, and how to control it.
 
 ## Attributes vs. labels
 
@@ -9,15 +9,31 @@ An OTLP log carries two attribute bags:
 - **Resource attributes** describe the *source* (e.g. `service.name`, `k8s.namespace.name`, `signoz.component`). One set per batch, stable, low-cardinality.
 - **Log-record attributes** describe the *individual event* (e.g. `k8s.event.reason`, `http.status_code`). Per-record, can vary on every line.
 
-A **label** is different from an attribute: labels form the **stream identity** in qryn/Loki. Every unique combination of label values is a separate stream with its own index entry. Attributes stay in the log payload; only *promoted* attributes become labels. Promoting a high-cardinality attribute (e.g. an event message or an id) to a label creates many streams and slows queries — the classic Loki cardinality anti-pattern.
+A **label** is different from an attribute: labels form the **stream identity** in Gigapipe/Loki. Every unique combination of label values is a separate stream with its own index entry. Attributes stay in the log payload; only *promoted* attributes become labels. Promoting a high-cardinality attribute (e.g. an event message or an id) to a label creates many streams and slows queries — the classic Loki cardinality anti-pattern.
 
 The `level` label is always derived from the log's severity and promoted automatically.
 
+## Default behaviour
+
+The two bags are treated differently, on purpose, because they carry different cardinality risk:
+
+- **Resource attributes** are low-cardinality (one set per source), so **all** of them are promoted to labels by default.
+- **Log-record attributes** are per-event and can be high-cardinality, so **none** of them are promoted by default — only the `level` label plus any attributes you explicitly name. Promoting all log attributes would let a single noisy attribute (an event message, a request id) create thousands of streams.
+
+`level` is always promoted, regardless of any setting.
+
+| | Promoted to labels by default |
+| --- | --- |
+| Resource attributes | **all** |
+| Log-record attributes | **none** (except `level`) |
+
 ## How to control which attributes become labels
 
-Two ways, checked independently for resource attrs and for log-record attrs.
+### Promote specific attributes
 
-1. **Exporter config** (applies to every log in the pipeline):
+Checked independently for each bag; works via config (whole pipeline) or per-payload hints (set by the sender).
+
+1. **Exporter config:**
 
    ```yaml
    exporters:
@@ -25,25 +41,37 @@ Two ways, checked independently for resource attrs and for log-record attrs.
        dsn: tcp://localhost:9000/?database=cloki
        clustered_clickhouse: false
        logs:
-         resource_labels: "service.name,k8s.namespace.name"   # only these resource attrs → labels
-         attribute_labels: "k8s.event.reason"                  # only these log attrs → labels
+         resource_labels: "service.name,k8s.namespace.name"   # promote only these resource attrs
+         attribute_labels: "k8s.event.reason"                  # promote only these log attrs
    ```
 
-2. **Per-payload hints** (set by the sender as attributes on the log/resource):
+2. **Per-payload hints** (attributes set by the sender on the log/resource):
    - `loki.resource.labels` — comma list of resource attributes to promote.
    - `loki.attribute.labels` — comma list of log-record attributes to promote.
    - `loki.tenant` — names the attribute whose value routes the log to a tenant (this is **not** a label).
    - `loki.format` — output body format.
 
-## Default behaviour
+For **resource** attributes, naming specific ones (via `resource_labels` or `loki.resource.labels`) also opts out of the promote-all default for that bag.
 
-For each bag, **if you name nothing** (no config key and no hint for that bag), the exporter promotes **all** attributes in that bag to labels. As soon as you set the config key **or** the matching hint for a bag, only the names you listed are promoted — that is your opt-out of the all-attributes default.
+### Promote *all* log attributes
+
+If you really want every log-record attribute as a label — and accept the cardinality cost — set:
+
+```yaml
+   logs:
+     promote_all_attributes: true
+```
+
+This is a blunt switch: when `true`, every log attribute becomes a label. It does **not** disable the specific selectors above (they always apply); it only turns the blanket export on. Default is `false`.
+
+## Control matrix
 
 | Resource attrs → labels | Log attrs → labels | How |
 | --- | --- | --- |
-| all (default) | all (default) | set nothing |
-| only listed | all (default) | set `resource_labels` or `loki.resource.labels` |
-| all (default) | only listed | set `attribute_labels` or `loki.attribute.labels` |
-| only listed | only listed | set both |
+| all (default) | only `level` (default) | set nothing |
+| all (default) | `level` + listed | set `attribute_labels` or `loki.attribute.labels` |
+| all (default) | all | set `promote_all_attributes: true` |
+| only listed | only `level` (default) | set `resource_labels` or `loki.resource.labels` |
+| only listed | `level` + listed | set `resource_labels` **and** `attribute_labels` |
 
-> **Cardinality tip:** resource attributes are safe to promote broadly. Log-record attributes are per-event and can be high-cardinality — prefer naming the specific ones you need via `attribute_labels` (or `loki.attribute.labels`) rather than relying on the promote-all default in high-volume pipelines.
+> **Cardinality tip:** resource attributes are safe to promote broadly. Log-record attributes are per-event — prefer naming the specific ones you need via `attribute_labels` (or `loki.attribute.labels`). Reach for `promote_all_attributes: true` only when you understand the label-cardinality impact on your Gigapipe/ClickHouse backend.

--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -135,11 +135,14 @@ func (e *logsExporter) convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs 
 		out = out.Merge(labels)
 	}
 
-	// Hints opt in to specific labels; unset hints keep the default of exporting all attrs.
-	if !hasResourceLabelsHint(logAttrs, resAttrs) {
+	// Selecting specific labels opts out of the default all-attrs export.
+	// A payload hint (loki.resource.labels / loki.attribute.labels) or the
+	// exporter config (resource_labels / attribute_labels) counts as an opt-in
+	// to specific labels; when neither is set, the default exports all attrs.
+	if !hasResourceLabelsHint(logAttrs, resAttrs) && e.resourceLabels == "" {
 		out = out.Merge(convertAttributesToLabels(resAttrs))
 	}
-	if !hasAttributeLabelsHint(logAttrs) {
+	if !hasAttributeLabelsHint(logAttrs) && e.attributeLabels == "" {
 		out = out.Merge(convertAttributesToLabels(logAttrs))
 	}
 	return out

--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -36,10 +36,11 @@ type logsExporter struct {
 
 	db clickhouse.Conn
 
-	attributeLabels string
-	resourceLabels  string
-	format          string
-	cluster         bool
+	attributeLabels      string
+	resourceLabels       string
+	promoteAllAttributes bool
+	format               string
+	cluster              bool
 }
 
 func newLogsExporter(logger *zap.Logger, cfg *Config, set *exporter.Settings) (*logsExporter, error) {
@@ -52,13 +53,14 @@ func newLogsExporter(logger *zap.Logger, cfg *Config, set *exporter.Settings) (*
 		return nil, err
 	}
 	exp := &logsExporter{
-		logger:          logger,
-		meter:           set.MeterProvider.Meter(typeStr),
-		db:              db,
-		format:          cfg.Logs.Format,
-		attributeLabels: cfg.Logs.AttributeLabels,
-		resourceLabels:  cfg.Logs.ResourceLabels,
-		cluster:         cfg.ClusteredClickhouse,
+		logger:               logger,
+		meter:                set.MeterProvider.Meter(typeStr),
+		db:                   db,
+		format:               cfg.Logs.Format,
+		attributeLabels:      cfg.Logs.AttributeLabels,
+		resourceLabels:       cfg.Logs.ResourceLabels,
+		promoteAllAttributes: cfg.Logs.PromoteAllAttributes,
+		cluster:              cfg.ClusteredClickhouse,
 	}
 	if err := initMetrics(exp.meter); err != nil {
 		exp.logger.Error(fmt.Sprintf("failed to init metrics: %s", err.Error()))
@@ -81,11 +83,6 @@ func hasResourceLabelsHint(logAttrs, resAttrs pcommon.Map) bool {
 		return true
 	}
 	_, found = logAttrs.Get(hintResources)
-	return found
-}
-
-func hasAttributeLabelsHint(logAttrs pcommon.Map) bool {
-	_, found := logAttrs.Get(hintAttributes)
 	return found
 }
 
@@ -135,15 +132,26 @@ func (e *logsExporter) convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs 
 		out = out.Merge(labels)
 	}
 
-	// Selecting specific labels opts out of the default all-attrs export.
-	// A payload hint (loki.resource.labels / loki.attribute.labels) or the
-	// exporter config (resource_labels / attribute_labels) counts as an opt-in
-	// to specific labels; when neither is set, the default exports all attrs.
+	// Resource attributes are low-cardinality (one set per source), so they are
+	// promoted by default. Selecting specific labels via the loki.resource.labels
+	// hint or the resource_labels config opts out of that default.
 	if !hasResourceLabelsHint(logAttrs, resAttrs) && e.resourceLabels == "" {
 		out = out.Merge(convertAttributesToLabels(resAttrs))
 	}
-	if !hasAttributeLabelsHint(logAttrs) && e.attributeLabels == "" {
+
+	// Log-record attributes are per-event and can be high-cardinality. Labels
+	// named via the loki.attribute.labels hint or the attribute_labels config
+	// are already promoted above. Promoting *all* log attributes is opt-in via
+	// promote_all_attributes; the flag only gates that blanket export and never
+	// blocks explicitly selected labels.
+	if e.promoteAllAttributes {
 		out = out.Merge(convertAttributesToLabels(logAttrs))
+	}
+
+	// The level label is always promoted, independent of promote_all_attributes,
+	// so severity stays queryable in the conservative default.
+	if level, found := logAttrs.Get(levelAttributeName); found {
+		out[model.LabelName(levelAttributeName)] = model.LabelValue(level.AsString())
 	}
 	return out
 }

--- a/exporter/qrynexporter/logs_test.go
+++ b/exporter/qrynexporter/logs_test.go
@@ -10,8 +10,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-func TestConvertAttributesAndMerge_DefaultIncludesAllAttrs(t *testing.T) {
-	exp := &logsExporter{}
+func TestConvertAttributesAndMerge_DefaultPromotesLevelAndResourcesOnly(t *testing.T) {
+	exp := &logsExporter{} // promoteAllAttributes defaults to false
 
 	logAttrs := pcommon.NewMap()
 	logAttrs.PutStr("k8s.namespace.name", "devnet")
@@ -21,15 +21,40 @@ func TestConvertAttributesAndMerge_DefaultIncludesAllAttrs(t *testing.T) {
 	resAttrs.PutStr("signoz.component", "otel-deployment")
 	resAttrs.PutStr("k8s.object.kind", "Pod")
 
-	addLogLevelAttributeAndHint(newLogRecord(plog.SeverityNumberWarn))
-
-	// Re-copy attrs after addLogLevelAttributeAndHint for a realistic flow.
 	log := newLogRecord(plog.SeverityNumberWarn)
 	logAttrs.CopyTo(log.Attributes())
 	addLogLevelAttributeAndHint(log)
 
 	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
 
+	// level is always promoted.
+	assert.Equal(t, model.LabelValue("WARN"), labels["level"])
+	// Resource attrs are promoted by default (low cardinality).
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+	assert.Equal(t, model.LabelValue("Pod"), labels["k8s.object.kind"])
+	// Log attrs are NOT promoted by default (cardinality guard).
+	assert.NotContains(t, labels, "k8s.namespace.name")
+	assert.NotContains(t, labels, "k8s.event.reason")
+}
+
+func TestConvertAttributesAndMerge_PromoteAllAttributesPromotesLogAttrs(t *testing.T) {
+	exp := &logsExporter{promoteAllAttributes: true}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+	logAttrs.PutStr("k8s.event.reason", "Unhealthy")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+	resAttrs.PutStr("k8s.object.kind", "Pod")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	// With the flag on, every attribute becomes a label.
 	assert.Equal(t, model.LabelValue("WARN"), labels["level"])
 	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
 	assert.Equal(t, model.LabelValue("Unhealthy"), labels["k8s.event.reason"])
@@ -56,7 +81,8 @@ func TestConvertAttributesAndMerge_RespectsResourceLabelsHint(t *testing.T) {
 
 	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
 	assert.NotContains(t, labels, "k8s.object.kind")
-	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
+	// Log attrs are not promoted by default.
+	assert.NotContains(t, labels, "k8s.namespace.name")
 }
 
 func TestConvertAttributesAndMerge_RespectsAttributeLabelsHint(t *testing.T) {
@@ -123,8 +149,8 @@ func TestConvertAttributesAndMerge_ResourceLabelsConfigOptsOutOfDefault(t *testi
 	// Only the configured resource attr is promoted; the rest are not.
 	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
 	assert.NotContains(t, labels, "k8s.object.kind")
-	// Log attrs keep the default all-attrs export.
-	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
+	// Log attrs are not promoted by default.
+	assert.NotContains(t, labels, "k8s.namespace.name")
 }
 
 func TestAddLogLevelAttributeAndHint_AppendsToExistingHint(t *testing.T) {

--- a/exporter/qrynexporter/logs_test.go
+++ b/exporter/qrynexporter/logs_test.go
@@ -81,6 +81,52 @@ func TestConvertAttributesAndMerge_RespectsAttributeLabelsHint(t *testing.T) {
 	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
 }
 
+func TestConvertAttributesAndMerge_AttributeLabelsConfigOptsOutOfDefault(t *testing.T) {
+	exp := &logsExporter{attributeLabels: "k8s.event.reason"}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+	logAttrs.PutStr("k8s.event.reason", "Unhealthy")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	// Only the configured log attr is promoted; the rest are not.
+	assert.Equal(t, model.LabelValue("Unhealthy"), labels["k8s.event.reason"])
+	assert.NotContains(t, labels, "k8s.namespace.name")
+	// Resource attrs keep the default all-attrs export.
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+}
+
+func TestConvertAttributesAndMerge_ResourceLabelsConfigOptsOutOfDefault(t *testing.T) {
+	exp := &logsExporter{resourceLabels: "signoz.component"}
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("k8s.namespace.name", "devnet")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("signoz.component", "otel-deployment")
+	resAttrs.PutStr("k8s.object.kind", "Pod")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	// Only the configured resource attr is promoted; the rest are not.
+	assert.Equal(t, model.LabelValue("otel-deployment"), labels["signoz.component"])
+	assert.NotContains(t, labels, "k8s.object.kind")
+	// Log attrs keep the default all-attrs export.
+	assert.Equal(t, model.LabelValue("devnet"), labels["k8s.namespace.name"])
+}
+
 func TestAddLogLevelAttributeAndHint_AppendsToExistingHint(t *testing.T) {
 	log := newLogRecord(plog.SeverityNumberWarn)
 	log.Attributes().PutStr(hintAttributes, "k8s.event.reason")


### PR DESCRIPTION
## Summary

Follow-up that **builds on #145** (@shivanshs9). #145 fixes the k8sevents
regression where OTLP resource and log attributes were dropped as Loki stream
labels, and restores the default of promoting all attributes while letting the
per-payload hints (`loki.resource.labels` / `loki.attribute.labels`) narrow the
set.

This PR closes one remaining gap: the exporter-level config
(`logs.attribute_labels` / `logs.resource_labels`) only *added* the selected
labels but did **not** suppress the promote-all default. An operator who set
`attribute_labels: "a,b"` still got every log attribute promoted to a label.

## What changed

- `logs.go` — setting `attribute_labels` (or `resource_labels`) now opts that
  bag out of the all-attributes default, exactly like the matching hint does.
  This gives a pipeline-wide, cardinality-safe knob for high-volume logs
  without changing the default behaviour for anyone who sets nothing.
- `logs_test.go` — added cases for both config keys opting out of the default.
- Docs — new `exporter/qrynexporter/docs/logs-labels.md` explaining attributes
  vs. labels, the config vs. hints control paths, the default-behaviour matrix,
  and a cardinality note; linked from the exporter README.

## Dependency

Stacked on #145 — until that merges, the diff here includes its commit. Please
review/merge #145 first.