### PR TITLE
ci: add Go version sync workflow

### DIFF
--- a/.github/workflows/go-version-sync.yml
+++ b/.github/workflows/go-version-sync.yml
@@ -1,0 +1,120 @@
+name: Go Version Sync
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
+  workflow_dispatch:      # Allow manual trigger
+
+jobs:
+  update-go-version:
+    runs-on: self-hosted
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest stable Go version
+        id: go-latest
+        run: |
+          LATEST_RAW=$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1)
+          LATEST="${LATEST_RAW#go}"
+          LATEST_MM=$(echo "${LATEST}" | grep -oE '^[0-9]+\.[0-9]+')
+          if [ -z "${LATEST}" ] || [ -z "${LATEST_MM}" ]; then
+            echo "Failed to determine the latest Go version" >&2
+            exit 1
+          fi
+          echo "version=${LATEST}" >> $GITHUB_OUTPUT
+          echo "version_mm=${LATEST_MM}" >> $GITHUB_OUTPUT
+          echo "Latest stable Go version: ${LATEST}"
+
+      - name: Get current Go version from go.mod
+        id: go-current
+        run: |
+          CURRENT=$(grep '^go ' go.mod | awk '{print $2}')
+          CURRENT_MM=$(echo "${CURRENT}" | grep -oE '^[0-9]+\.[0-9]+')
+          echo "version=${CURRENT}" >> $GITHUB_OUTPUT
+          echo "version_mm=${CURRENT_MM}" >> $GITHUB_OUTPUT
+          echo "Current Go version: ${CURRENT}"
+
+      - name: Check if update is needed
+        id: check
+        run: |
+          LATEST="${{ steps.go-latest.outputs.version }}"
+          CURRENT="${{ steps.go-current.outputs.version }}"
+          if [ "${LATEST}" != "${CURRENT}" ]; then
+            NEWER=$(printf '%s\n%s\n' "${CURRENT}" "${LATEST}" | sort -V | tail -1)
+            if [ "${NEWER}" = "${LATEST}" ]; then
+              echo "needed=true" >> $GITHUB_OUTPUT
+              echo "Go update needed: ${CURRENT} -> ${LATEST}"
+            else
+              echo "needed=false" >> $GITHUB_OUTPUT
+              echo "Current version ${CURRENT} is already newer than ${LATEST}, no update needed"
+            fi
+          else
+            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "Go version is already up to date: ${CURRENT}"
+          fi
+
+      - name: Update Go version in go.mod
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          LATEST="${{ steps.go-latest.outputs.version }}"
+          CURRENT="${{ steps.go-current.outputs.version }}"
+          CURRENT_ESC=$(printf '%s\n' "${CURRENT}" | sed 's/[.[\*^$]/\\&/g')
+          LATEST_ESC=$(printf '%s\n' "${LATEST}" | sed 's/[&/\]/\\&/g')
+          sed -i "s/^go ${CURRENT_ESC}$/go ${LATEST_ESC}/" go.mod
+          echo "Updated go.mod: ${CURRENT} -> ${LATEST}"
+
+      - name: Update Go version in Dockerfile
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          LATEST="${{ steps.go-latest.outputs.version }}"
+          CURRENT="${{ steps.go-current.outputs.version }}"
+          CURRENT_ESC=$(printf '%s\n' "${CURRENT}" | sed 's/[.[\*^$]/\\&/g')
+          LATEST_ESC=$(printf '%s\n' "${LATEST}" | sed 's/[&/\]/\\&/g')
+          sed -i "s/golang:${CURRENT_ESC}-alpine/golang:${LATEST_ESC}-alpine/g" cmd/otel-collector/Dockerfile
+          echo "Updated Dockerfile: ${CURRENT} -> ${LATEST}"
+
+      - name: Set up Go ${{ steps.go-latest.outputs.version }}
+        if: steps.check.outputs.needed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go-latest.outputs.version }}
+
+      - name: Run go mod tidy
+        if: steps.check.outputs.needed == 'true'
+        run: go mod tidy
+
+      - name: Create Pull Request
+        if: steps.check.outputs.needed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Go version to ${{ steps.go-latest.outputs.version }}"
+          title: "chore: update Go version to ${{ steps.go-latest.outputs.version }}"
+          body: |
+            ## Go Version Update
+
+            This PR was automatically created by the [Go Version Sync](${{ github.server_url }}/${{ github.repository }}/actions/workflows/go-version-sync.yml) workflow.
+
+            | | Version |
+            |---|---|
+            | **Previous** | `${{ steps.go-current.outputs.version }}` |
+            | **Updated**  | `${{ steps.go-latest.outputs.version }}` |
+
+            ### Files Changed
+            - `go.mod` — updated `go` directive
+            - `cmd/otel-collector/Dockerfile` — updated `golang` builder image
+            - `go.sum` — regenerated via `go mod tidy`
+
+            > **Manual step (on minor bumps only):** update `go-version` in `.github/workflows/lint-and-test.yml` to `'${{ steps.go-latest.outputs.version_mm }}'` — workflow files cannot be updated automatically due to `GITHUB_TOKEN` restrictions.
+
+            ---
+            *Keeping the project up-to-date with Go releases ensures compatibility and security enhancements.*
+          branch: chore/go-version-update
+          delete-branch: true
+          labels: |
+            dependencies
+            go


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that keeps the repo on the latest stable Go release automatically.

Each week (and on manual `workflow_dispatch`), it queries `https://go.dev/VERSION`, compares against the pinned version, and — only when go.dev is newer — opens a PR that bumps:

- `go.mod` — the `go` directive
- `cmd/otel-collector/Dockerfile` — the `golang:<ver>-alpine` builder image
- `go.sum` — regenerated via `go mod tidy`

Runs on `self-hosted` (org runner), same as the rest of metrico.

## Not automated

`go-version` in `.github/workflows/lint-and-test.yml` (major.minor, e.g. `'1.26'`) is left as a documented manual step in the generated PR body — `GITHUB_TOKEN` cannot modify workflow files, and this value only changes on minor bumps.

## Repo settings required

- **Settings → Actions → General → Workflow permissions:** enable *"Allow GitHub Actions to create and approve pull requests"* (needed for the workflow to open the PR).