### PR TITLE
fix(clickhouseprofileexporter): avoid nil deref on empty profile tree (#142)

### DIFF
--- a/exporter/clickhouseprofileexporter/ch/access_native_columnar.go
+++ b/exporter/clickhouseprofileexporter/ch/access_native_columnar.go
@@ -436,5 +436,12 @@ func readTreeFromMap(m pcommon.Map) (*PooledTree, error) {
 		res.data[i][1] = fnId
 		res.data[i][2] = nodeId
 	}
+
+	// An empty tree (treeSize <= 0) leaves res nil. Return a valid pooled tree
+	// with no rows instead, so callers can append res.data and release res via
+	// trees.put without a nil-pointer dereference (see #142).
+	if res == nil {
+		res = trees.get(0, 0)
+	}
 	return res, nil
 }

--- a/exporter/clickhouseprofileexporter/ch/access_native_columnar_test.go
+++ b/exporter/clickhouseprofileexporter/ch/access_native_columnar_test.go
@@ -1,0 +1,30 @@
+package ch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// Regression test for #142: a profile carrying an empty tree (treeSize <= 0)
+// used to make readTreeFromMap return (nil, nil), and the caller then
+// dereferenced the nil *PooledTree (tree = append(tree, _tree.data)),
+// crashing with SIGSEGV.
+func TestReadTreeFromMap_EmptyTreeDoesNotPanic(t *testing.T) {
+	m := pcommon.NewMap()
+	// A single 0x00 byte decodes as varint 0 -> treeSize == 0.
+	m.PutEmptyBytes("tree").FromRaw([]byte{0x00})
+
+	res, err := readTreeFromMap(m)
+	require.NoError(t, err)
+	require.NotNil(t, res, "empty tree must yield a non-nil PooledTree, not nil")
+	assert.Empty(t, res.data)
+
+	// Both the caller's data append and the pool release must be safe.
+	assert.NotPanics(t, func() {
+		_ = append([]interface{}{}, res.data)
+		trees.put(res)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #142 — a random `SIGSEGV` when uploading profiles.

`readTreeFromMap` starts its result as a nil `*PooledTree` and only assigns it inside the `for i < treeSize` loop. When a profile's tree is empty (`treeSize <= 0`), the loop never runs and the function returns `(nil, nil)`. `InsertBatch` then:

- dereferences the nil pointer at `tree = append(tree, _tree.data)`, and
- calls `trees.put(nil)` on release,

crashing with the exact `invalid memory address or nil pointer dereference` in the issue. It's intermittent because only profiles carrying an empty tree trigger it.

## Fix

Return a valid empty pooled tree (`trees.get(0, 0)`) when `treeSize <= 0`, so the columnar append and the pool release are both safe. The row is inserted with an empty tree, keeping the columnar arrays aligned.

## Test

Adds `TestReadTreeFromMap_EmptyTreeDoesNotPanic` — feeds a tree with `treeSize == 0` and asserts a non-nil result plus no panic on append/release.