### PR TITLE
fix(qrynexporter): harden clusterKey type assertion against nil (#109)

### DIFF
--- a/exporter/qrynexporter/logs.go
+++ b/exporter/qrynexporter/logs.go
@@ -465,7 +465,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 		}
 	}
 
-	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.db, samples, timeSeries); err != nil {
+	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.logger, e.db, samples, timeSeries); err != nil {
 		otelcolExporterQrynBatchInsertDurationMillis.Record(ctx, time.Now().UnixMilli()-start.UnixMilli(), metric.WithAttributeSet(*newOtelcolAttrSetBatch(errorCodeError, dataTypeLogs)))
 		e.logger.Error(fmt.Sprintf("failed to insert batch: [%s]", err.Error()))
 		return err
@@ -475,8 +475,16 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 	return nil
 }
 
-func batchSamplesAndTimeSeries(ctx context.Context, db clickhouse.Conn, samples []Sample, timeSeries []TimeSerie) error {
-	isCluster := ctx.Value(clusterKey).(bool)
+func batchSamplesAndTimeSeries(ctx context.Context, logger *zap.Logger, db clickhouse.Conn, samples []Sample, timeSeries []TimeSerie) error {
+	// The caller injects the cluster flag via clusterKey. A missing flag can only
+	// mean a context-propagation bug (see #109). Degrading to non-clustered would
+	// steer inserts at the wrong schema and fail anyway, so treat it as a hard
+	// error: log it and abort the batch rather than panicking on a nil assertion.
+	isCluster, ok := ctx.Value(clusterKey).(bool)
+	if !ok {
+		logger.Error("cluster flag missing from context (context-propagation bug, see #109)")
+		return fmt.Errorf("cluster flag missing from context")
+	}
 	samplesBatch, err := db.PrepareBatch(ctx, samplesSQL(isCluster))
 	if err != nil {
 		return err

--- a/exporter/qrynexporter/logs_test.go
+++ b/exporter/qrynexporter/logs_test.go
@@ -1,6 +1,7 @@
 package qrynexporter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
 )
 
 func TestConvertAttributesAndMerge_DefaultPromotesLevelAndResourcesOnly(t *testing.T) {
@@ -173,6 +175,17 @@ func TestAddLogLevelAttributeAndHint_DoesNotInjectHint(t *testing.T) {
 	_, found := log.Attributes().Get(hintAttributes)
 	assert.False(t, found)
 	assert.Equal(t, "WARN", log.Attributes().AsRaw()["level"])
+}
+
+// A missing cluster flag is a context-propagation bug: the batch helper must log
+// and return an error rather than panicking on a nil type assertion (see #109).
+// The guard returns before the ClickHouse connection is touched, so a nil db is
+// fine.
+func TestBatchSamplesAndTimeSeries_MissingClusterFlagErrors(t *testing.T) {
+	err := batchSamplesAndTimeSeries(context.Background(), zap.NewNop(), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error when the cluster flag is missing from context")
+	}
 }
 
 func newLogRecord(severity plog.SeverityNumber) plog.LogRecord {

--- a/exporter/qrynexporter/metrics.go
+++ b/exporter/qrynexporter/metrics.go
@@ -506,7 +506,7 @@ func (e *metricsExporter) pushMetricsData(ctx context.Context, md pmetric.Metric
 		}
 	}
 
-	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.db, samples, timeSeries); err != nil {
+	if err := batchSamplesAndTimeSeries(context.WithValue(ctx, clusterKey, e.cluster), e.logger, e.db, samples, timeSeries); err != nil {
 		otelcolExporterQrynBatchInsertDurationMillis.Record(ctx, time.Now().UnixMilli()-start.UnixMilli(), metric.WithAttributeSet(*newOtelcolAttrSetBatch(errorCodeError, dataTypeMetrics)))
 		e.logger.Error(fmt.Sprintf("failed to insert batch: [%s]", err.Error()))
 		return err

--- a/exporter/qrynexporter/traces.go
+++ b/exporter/qrynexporter/traces.go
@@ -170,7 +170,15 @@ func extractScopeTags(il pcommon.InstrumentationScope, tags map[string]string) {
 }
 
 func (e *tracesExporter) exportResourceSapns(ctx context.Context, resourceSpans ptrace.ResourceSpansSlice) error {
-	isCluster := ctx.Value(clusterKey).(bool)
+	// The caller injects the cluster flag via clusterKey. A missing flag can only
+	// mean a context-propagation bug (see #109). Degrading to non-clustered would
+	// steer inserts at the wrong schema and fail anyway, so treat it as a hard
+	// error: log it and abort rather than panicking on a nil assertion.
+	isCluster, ok := ctx.Value(clusterKey).(bool)
+	if !ok {
+		e.logger.Error("cluster flag missing from context (context-propagation bug, see #109)")
+		return fmt.Errorf("cluster flag missing from context")
+	}
 	var batch driver.Batch
 	var err error
 	if e.clientSide {


### PR DESCRIPTION
## Summary

Hardens the cluster-flag read that can panic with `interface conversion: interface {} is nil, not bool` (#109).

`batchSamplesAndTimeSeries` (logs/metrics) and `exportResourceSapns` (traces) read the cluster flag with an unchecked assertion:

```go
isCluster := ctx.Value(clusterKey).(bool)
```

## Root cause of #109

The original panic was a key-type mismatch: the reader looked up the plain string `"cluster"` while the writer stored the flag under the typed `clusterKey` (`type contextKey string`). Context keys compare by type *and* value, so the lookup missed, returned `nil`, and the assertion panicked. That was fixed in Oct 2024 (reader switched to `clusterKey`), so the panic cannot recur on `main`.

This PR removes the remaining foot-gun so the same class of bug — any future path that fails to propagate `clusterKey` — degrades safely instead of panicking.

## Fix

Use the comma-ok form. On a missing flag, log at error level and return an error:

```go
isCluster, ok := ctx.Value(clusterKey).(bool)
if !ok {
    logger.Error("cluster flag missing from context (context-propagation bug, see #109)")
    return fmt.Errorf("cluster flag missing from context")
}
```

Degrading to non-clustered would steer inserts at the wrong schema and fail the insert anyway, so this aborts the batch loudly rather than masking the bug.

## No change for non-clustered deployments

Clustering is optional and off by default (`clustered_clickhouse` defaults to `false`). The flag is always injected into the context — value `false` for non-clustered — so `ok` is always `true` on every real path and the guard never fires. Non-clustered inserts behave exactly as before.

Adds a regression test for the guard.
