### PR TITLE
fix(clickhouseprofileexporter): keep profile columns aligned on insert (#120)

### DIFF
--- a/exporter/clickhouseprofileexporter/ch/access_native_columnar.go
+++ b/exporter/clickhouseprofileexporter/ch/access_native_columnar.go
@@ -82,170 +82,238 @@ func (ch *clickhouseAccessNativeColumnar) InsertBatch(ls plog.Logs) (int, error)
 	}
 
 	// this implementation is tightly coupled to how pyroscope-java and pyroscopereceiver work
-	timestamp_ns := make([]uint64, 0)
-	typ := make([]string, 0)
-	service_name := make([]string, 0)
-	values_agg := make([][]tuple, 0)
-	sample_types_units := make([][]tuple, 0)
-	period_type := make([]string, 0)
-	period_unit := make([]string, 0)
-	tags := make([][]tuple, 0)
-	duration_ns := make([]uint64, 0)
-	payload_type := make([]string, 0)
-	payload := make([][]byte, 0)
-	tree := make([][]tuple, 0)
-	var pooledTrees []*PooledTree
-	functions := make([][]tuple, 0)
+	cols := &profileColumns{}
+	// Return pooled trees to the pool on every exit path (success or error).
+	defer cols.release()
 
 	rl := ls.ResourceLogs()
-	var (
-		lr     plog.LogRecordSlice
-		r      plog.LogRecord
-		m      pcommon.Map
-		tmp    pcommon.Value
-		tm     map[string]any
-		offset int
-		s      int
-		idx    int
-	)
 	for i := 0; i < rl.Len(); i++ {
-		lr = rl.At(i).ScopeLogs().At(0).LogRecords()
-		for s = 0; s < lr.Len(); s++ {
-			r = lr.At(s)
-			m = r.Attributes()
-			timestamp_ns = append(timestamp_ns, uint64(r.Timestamp()))
-
-			tmp, _ = m.Get(columnType)
-			typ = append(typ, tmp.AsString())
-
-			tmp, _ = m.Get(columnServiceName)
-			service_name = append(service_name, tmp.AsString())
-
-			sample_types, _ := m.Get("sample_types")
-			sample_units, _ := m.Get("sample_units")
-			sample_types_array, err := valueToStringArray(sample_types)
-			if err != nil {
-				return 0, err
-			}
-			sample_units_array, err := valueToStringArray(sample_units)
-			if err != nil {
-				return 0, err
-			}
-			values_agg_raw, ok := m.Get(columnValuesAgg)
-			if ok {
-				values_agg_tuple, err := valueAggToTuple(&values_agg_raw)
-				if err != nil {
+		sls := rl.At(i).ScopeLogs()
+		// Iterate every scope, not just the first, so records from additional
+		// instrumentation scopes are not silently dropped.
+		for si := 0; si < sls.Len(); si++ {
+			lr := sls.At(si).LogRecords()
+			for s := 0; s < lr.Len(); s++ {
+				if err := cols.appendRecord(lr.At(s)); err != nil {
 					return 0, err
 				}
-				values_agg = append(values_agg, values_agg_tuple)
+				idx := cols.rowCount() - 1
+				ch.logger.Debug(
+					fmt.Sprintf("batch insert prepared row %d", idx),
+					zap.Uint64(columnTimestampNs, cols.timestampNs[idx]),
+					zap.String(columnType, cols.typ[idx]),
+					zap.String(columnServiceName, cols.serviceName[idx]),
+					zap.String(columnPeriodType, cols.periodType[idx]),
+					zap.String(columnPeriodUnit, cols.periodUnit[idx]),
+					zap.Any(columnSampleTypesUnits, cols.sampleTypesUnits[idx]),
+					zap.String(columnPayloadType, cols.payloadType[idx]),
+				)
 			}
-			sample_types_units_item := make([]tuple, len(sample_types_array))
-			for i, v := range sample_types_array {
-				sample_types_units_item[i] = tuple{v, sample_units_array[i]}
-			}
-			sample_types_units = append(sample_types_units, sample_types_units_item)
-
-			tmp, _ = m.Get(columnPeriodType)
-			period_type = append(period_type, tmp.AsString())
-
-			tmp, _ = m.Get(columnPeriodUnit)
-			period_unit = append(period_unit, tmp.AsString())
-
-			tmp, _ = m.Get(columnTags)
-			tm = tmp.Map().AsRaw()
-			tag, j := make([]tuple, len(tm)), 0
-			for k, v := range tm {
-				tag[j] = tuple{k, v.(string)}
-				j++
-			}
-			tags = append(tags, tag)
-
-			tmp, _ = m.Get(columnDurationNs)
-			dur, _ := strconv.ParseUint(tmp.Str(), 10, 64)
-			duration_ns = append(duration_ns, dur)
-
-			tmp, _ = m.Get(columnPayloadType)
-			payload_type = append(payload_type, tmp.AsString())
-
-			payload = append(payload, r.Body().Bytes().AsRaw())
-
-			_functions, err := readFunctionsFromMap(m)
-			if err != nil {
-				return 0, err
-			}
-
-			functions = append(functions, _functions)
-
-			_tree, err := readTreeFromMap(m)
-			if err != nil {
-				return 0, err
-			}
-
-			pooledTrees = append(pooledTrees, _tree)
-			tree = append(tree, _tree.data)
-
-			idx = offset + s
-			ch.logger.Debug(
-				fmt.Sprintf("batch insert prepared row %d", idx),
-				zap.Uint64(columnTimestampNs, timestamp_ns[idx]),
-				zap.String(columnType, typ[idx]),
-				zap.String(columnServiceName, service_name[idx]),
-				zap.String(columnPeriodType, period_type[idx]),
-				zap.String(columnPeriodUnit, period_unit[idx]),
-				zap.Any(columnSampleTypesUnits, sample_types_units[idx]),
-				zap.String(columnPayloadType, payload_type[idx]),
-			)
 		}
-		offset += s
+	}
+
+	// The columnar insert requires every column to have the same length. Guard
+	// that invariant explicitly: a mismatch means a record skipped one of the
+	// appends, so fail with a clear error instead of a cryptic driver failure
+	// or silent data loss (see #120).
+	if err := cols.consistent(); err != nil {
+		return 0, fmt.Errorf("refusing to insert misaligned profile batch: %w", err)
 	}
 
 	// column order here should match table column order
-	if err := b.Column(0).Append(timestamp_ns); err != nil {
+	if err := b.Column(0).Append(cols.timestampNs); err != nil {
 		return 0, err
 	}
-	if err := b.Column(1).Append(typ); err != nil {
+	if err := b.Column(1).Append(cols.typ); err != nil {
 		return 0, err
 	}
-	if err := b.Column(2).Append(service_name); err != nil {
+	if err := b.Column(2).Append(cols.serviceName); err != nil {
 		return 0, err
 	}
-	if err := b.Column(3).Append(sample_types_units); err != nil {
+	if err := b.Column(3).Append(cols.sampleTypesUnits); err != nil {
 		return 0, err
 	}
-	if err := b.Column(4).Append(period_type); err != nil {
+	if err := b.Column(4).Append(cols.periodType); err != nil {
 		return 0, err
 	}
-	if err := b.Column(5).Append(period_unit); err != nil {
+	if err := b.Column(5).Append(cols.periodUnit); err != nil {
 		return 0, err
 	}
-	if err := b.Column(6).Append(tags); err != nil {
+	if err := b.Column(6).Append(cols.tags); err != nil {
 		return 0, err
 	}
-	if err := b.Column(7).Append(duration_ns); err != nil {
+	if err := b.Column(7).Append(cols.durationNs); err != nil {
 		return 0, err
 	}
-	if err := b.Column(8).Append(payload_type); err != nil {
-		return 0, err
-	}
-
-	if err := b.Column(9).Append(payload); err != nil {
-		return 0, err
-	}
-	if err := b.Column(10).Append(values_agg); err != nil {
+	if err := b.Column(8).Append(cols.payloadType); err != nil {
 		return 0, err
 	}
 
-	if err := b.Column(11).Append(tree); err != nil {
+	if err := b.Column(9).Append(cols.payload); err != nil {
 		return 0, err
 	}
-	if err := b.Column(12).Append(functions); err != nil {
+	if err := b.Column(10).Append(cols.valuesAgg); err != nil {
 		return 0, err
 	}
-	err = b.Send()
-	for _, tpls := range pooledTrees {
-		trees.put(tpls)
+
+	if err := b.Column(11).Append(cols.tree); err != nil {
+		return 0, err
 	}
-	return offset, err
+	if err := b.Column(12).Append(cols.functions); err != nil {
+		return 0, err
+	}
+	if err := b.Send(); err != nil {
+		return 0, err
+	}
+	return cols.rowCount(), nil
+}
+
+// profileColumns accumulates one profiles_input row per profile record across
+// all columns. The columnar ClickHouse insert requires every column slice to
+// have the same length, so appendRecord always appends exactly one element to
+// every column, and consistent() verifies the invariant before inserting.
+type profileColumns struct {
+	timestampNs      []uint64
+	typ              []string
+	serviceName      []string
+	sampleTypesUnits [][]tuple
+	periodType       []string
+	periodUnit       []string
+	tags             [][]tuple
+	durationNs       []uint64
+	payloadType      []string
+	payload          [][]byte
+	valuesAgg        [][]tuple
+	tree             [][]tuple
+	functions        [][]tuple
+	pooledTrees      []*PooledTree
+}
+
+// rowCount is the number of records appended so far.
+func (c *profileColumns) rowCount() int {
+	return len(c.timestampNs)
+}
+
+// appendRecord extracts one profile record into every column. It appends
+// exactly one element per column, tolerating optional/malformed fields rather
+// than desyncing the columns or panicking.
+func (c *profileColumns) appendRecord(r plog.LogRecord) error {
+	m := r.Attributes()
+	c.timestampNs = append(c.timestampNs, uint64(r.Timestamp()))
+
+	tmp, _ := m.Get(columnType)
+	c.typ = append(c.typ, tmp.AsString())
+
+	tmp, _ = m.Get(columnServiceName)
+	c.serviceName = append(c.serviceName, tmp.AsString())
+
+	sampleTypes, _ := m.Get("sample_types")
+	sampleUnits, _ := m.Get("sample_units")
+	sampleTypesArray, err := valueToStringArray(sampleTypes)
+	if err != nil {
+		return err
+	}
+	sampleUnitsArray, err := valueToStringArray(sampleUnits)
+	if err != nil {
+		return err
+	}
+	sampleTypesUnitsItem := make([]tuple, len(sampleTypesArray))
+	for n, v := range sampleTypesArray {
+		sampleTypesUnitsItem[n] = tuple{v, sampleUnitsArray[n]}
+	}
+	c.sampleTypesUnits = append(c.sampleTypesUnits, sampleTypesUnitsItem)
+
+	tmp, _ = m.Get(columnPeriodType)
+	c.periodType = append(c.periodType, tmp.AsString())
+
+	tmp, _ = m.Get(columnPeriodUnit)
+	c.periodUnit = append(c.periodUnit, tmp.AsString())
+
+	tmp, _ = m.Get(columnTags)
+	tm := tmp.Map().AsRaw()
+	tag, ti := make([]tuple, len(tm)), 0
+	for k, v := range tm {
+		// Tolerate non-string tag values instead of panicking on a failed
+		// type assertion.
+		sv, _ := v.(string)
+		tag[ti] = tuple{k, sv}
+		ti++
+	}
+	c.tags = append(c.tags, tag)
+
+	tmp, _ = m.Get(columnDurationNs)
+	dur, _ := strconv.ParseUint(tmp.Str(), 10, 64)
+	c.durationNs = append(c.durationNs, dur)
+
+	tmp, _ = m.Get(columnPayloadType)
+	c.payloadType = append(c.payloadType, tmp.AsString())
+
+	c.payload = append(c.payload, r.Body().Bytes().AsRaw())
+
+	// values_agg is optional on the record; append an empty entry when it is
+	// absent so the column stays aligned with the rest (this missing append was
+	// the root cause of #120).
+	if valuesAggRaw, ok := m.Get(columnValuesAgg); ok {
+		valuesAggTuple, err := valueAggToTuple(&valuesAggRaw)
+		if err != nil {
+			return err
+		}
+		c.valuesAgg = append(c.valuesAgg, valuesAggTuple)
+	} else {
+		c.valuesAgg = append(c.valuesAgg, []tuple{})
+	}
+
+	functions, err := readFunctionsFromMap(m)
+	if err != nil {
+		return err
+	}
+	c.functions = append(c.functions, functions)
+
+	t, err := readTreeFromMap(m)
+	if err != nil {
+		return err
+	}
+	c.pooledTrees = append(c.pooledTrees, t)
+	c.tree = append(c.tree, t.data)
+
+	return nil
+}
+
+// consistent verifies every column has exactly rowCount elements.
+func (c *profileColumns) consistent() error {
+	n := c.rowCount()
+	for _, col := range []struct {
+		name string
+		got  int
+	}{
+		{"type", len(c.typ)},
+		{"service_name", len(c.serviceName)},
+		{"sample_types_units", len(c.sampleTypesUnits)},
+		{"period_type", len(c.periodType)},
+		{"period_unit", len(c.periodUnit)},
+		{"tags", len(c.tags)},
+		{"duration_ns", len(c.durationNs)},
+		{"payload_type", len(c.payloadType)},
+		{"payload", len(c.payload)},
+		{"values_agg", len(c.valuesAgg)},
+		{"tree", len(c.tree)},
+		{"functions", len(c.functions)},
+	} {
+		if col.got != n {
+			return fmt.Errorf("column %q has length %d, expected %d", col.name, col.got, n)
+		}
+	}
+	return nil
+}
+
+// release returns the borrowed pooled trees to the pool so they can be reused.
+func (c *profileColumns) release() {
+	for _, t := range c.pooledTrees {
+		if t != nil {
+			trees.put(t)
+		}
+	}
+	c.pooledTrees = nil
 }
 
 // Closes the clickhouse connection pool

--- a/exporter/clickhouseprofileexporter/ch/access_native_columnar_insertbatch_test.go
+++ b/exporter/clickhouseprofileexporter/ch/access_native_columnar_insertbatch_test.go
@@ -1,0 +1,98 @@
+package ch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// buildProfileRecord constructs a LogRecord shaped like what pyroscopereceiver
+// emits, with just enough valid data for appendRecord to consume it.
+func buildProfileRecord(t *testing.T, withValuesAgg bool, tags map[string]any) plog.LogRecord {
+	t.Helper()
+	lr := plog.NewLogRecord()
+	a := lr.Attributes()
+	a.PutStr(columnType, "process_cpu")
+	a.PutStr(columnServiceName, "svc")
+
+	st := a.PutEmptySlice("sample_types")
+	st.AppendEmpty().SetStr("cpu")
+	su := a.PutEmptySlice("sample_units")
+	su.AppendEmpty().SetStr("nanoseconds")
+
+	a.PutStr(columnPeriodType, "cpu")
+	a.PutStr(columnPeriodUnit, "nanoseconds")
+
+	tagMap := a.PutEmptyMap(columnTags)
+	for k, v := range tags {
+		switch tv := v.(type) {
+		case string:
+			tagMap.PutStr(k, tv)
+		case int:
+			tagMap.PutInt(k, int64(tv))
+		}
+	}
+
+	a.PutStr(columnDurationNs, "10")
+	a.PutStr(columnPayloadType, "0")
+
+	// functions: varint size 0 -> no entries.
+	a.PutEmptyBytes("functions").FromRaw([]byte{0x00})
+	// tree: treeSize 1 (varint zig-zag of 1 == 0x02), one node with 0 children.
+	a.PutEmptyBytes("tree").FromRaw([]byte{0x02, 0x00, 0x00, 0x00, 0x00})
+
+	if withValuesAgg {
+		va := a.PutEmptySlice(columnValuesAgg)
+		inner := va.AppendEmpty().SetEmptySlice()
+		inner.AppendEmpty().SetStr("cpu:nanoseconds")
+		inner.AppendEmpty().SetInt(160000000)
+		inner.AppendEmpty().SetInt(14)
+	}
+
+	lr.Body().SetEmptyBytes().FromRaw([]byte("payload"))
+	return lr
+}
+
+// Regression test for #120: a record without values_agg must not desync the
+// columns. Before the fix, values_agg was only appended when present, so a
+// mixed batch produced unequal column lengths and the whole insert failed.
+func TestProfileColumns_MissingValuesAggStaysAligned(t *testing.T) {
+	cols := &profileColumns{}
+
+	require.NoError(t, cols.appendRecord(buildProfileRecord(t, true, nil)))
+	require.NoError(t, cols.appendRecord(buildProfileRecord(t, false, nil)))
+	defer cols.release()
+
+	assert.Equal(t, 2, cols.rowCount())
+	assert.Len(t, cols.valuesAgg, 2, "values_agg must have one entry per record")
+	assert.NoError(t, cols.consistent(), "all columns must stay length-aligned")
+}
+
+// Non-string tag values used to panic on tag[j] = tuple{k, v.(string)}.
+func TestProfileColumns_NonStringTagDoesNotPanic(t *testing.T) {
+	cols := &profileColumns{}
+	rec := buildProfileRecord(t, true, map[string]any{"host": "a", "count": 5})
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, cols.appendRecord(rec))
+	})
+	defer cols.release()
+
+	assert.Equal(t, 1, cols.rowCount())
+	assert.Len(t, cols.tags[0], 2)
+	assert.NoError(t, cols.consistent())
+}
+
+// consistent() must reject a batch whose columns drifted out of alignment.
+func TestProfileColumns_ConsistentDetectsMismatch(t *testing.T) {
+	cols := &profileColumns{
+		timestampNs: []uint64{1, 2},
+		typ:         []string{"a", "b"},
+		serviceName: []string{"s"}, // deliberately short
+	}
+	err := cols.consistent()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_name")
+}


### PR DESCRIPTION
## Summary

Fixes #120 — pyroscope profiles are received but never land in ClickHouse (the `profiles*` tables stay empty).

### Root cause

The profile exporter inserts via the **columnar** ClickHouse API (`b.Column(i).Append(slice)`), which requires every column slice to have the same length (= row count). In `InsertBatch`, every column appended once per record **except `values_agg`**, which was appended only when the attribute was present:

```go
values_agg_raw, ok := m.Get(columnValuesAgg)
if ok {
    values_agg = append(values_agg, ...)
}
// no else → column falls one short for records without values_agg
```

Any batch containing a record without `values_agg` produced unequal column lengths, so `Send()` failed and the **entire batch** was rejected — no profiles inserted.

(The row-based exporters — logs/metrics/traces — use `AppendStruct` and are not affected by this class of bug.)

## Changes

Extracted the per-record column building into a testable `profileColumns` type and fixed the alignment plus related robustness issues found in the same function:

- **`values_agg`**: append an empty entry when absent, so the column stays aligned (the direct #120 fix).
- **Multi-scope**: iterate every `ScopeLogs`, not just `At(0)`, so records in additional instrumentation scopes are no longer silently dropped.
- **Tag values**: use a comma-ok assertion so a non-string tag value no longer panics the collector.
- **Bookkeeping**: replace the manual `offset`/`s`/`idx` indexing with `len()`-based indexing.
- **Pooling**: release borrowed pooled trees on every exit path via `defer` (previously an error mid-loop skipped the release and defeated the pool).
- **Invariant guard**: verify all columns are equal length before inserting, and fail with a clear error instead of a cryptic driver failure or silent loss.

## Tests

New unit tests on `profileColumns` (no ClickHouse needed):
- mixed batch (one record with `values_agg`, one without) stays length-aligned — the #120 regression;
- non-string tag value does not panic;
- `consistent()` detects a deliberately misaligned batch.

`go build`, `go vet`, `go test ./...` all pass.

## Note

Empty-tree nil handling in `readTreeFromMap` (the SIGSEGV) is a separate fix in #151; the two touch the same file but different functions and are independent. Both are needed for fully robust profile ingestion.
