### PR TITLE
test(gigapipeexporter): raise coverage 24%->87% with in-memory fakes

### DIFF
--- a/exporter/gigapipeexporter/README.md
+++ b/exporter/gigapipeexporter/README.md
@@ -7,6 +7,22 @@
 | Distributions            | [Gigapipe]            |
 
 
+# Schema model
+
+This exporter writes the Gigapipe/qryn **polyglot fingerprint schema**
+(`samples_v3` + `time_series` keyed by a Loki-style fingerprint; `tempo_traces` +
+`tempo_traces_attrs_gin`; Prometheus-compliant metric names and labels), so a
+single ClickHouse instance is queryable through the Loki, Prometheus, Tempo and
+Pyroscope APIs served by [Gigapipe](https://github.com/metrico/gigapipe).
+
+This is a different goal from the generic contrib
+[`clickhouseexporter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter),
+which writes generic OTel tables intended to be queried as ClickHouse SQL. Choose
+`clickhouseexporter` to query ClickHouse directly; choose this exporter to serve
+the LogQL/PromQL/Tempo/Pyroscope query surface. See
+[Schema model, and how this differs from `clickhouseexporter`](docs/schema.md).
+
+
 # Configuration options:
 - `dsn` (required): Data Source Name for Clickhouse.
   - Example: `tcp://localhost:9000/qryn`

--- a/exporter/gigapipeexporter/db.go
+++ b/exporter/gigapipeexporter/db.go
@@ -1,0 +1,30 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gigapipeexporter
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// chConn is the narrow subset of clickhouse.Conn that the exporters actually use.
+// It exists purely as a testing seam: the *clickhouse.Conn value returned by
+// clickhouse.Open already satisfies it, so production wiring and runtime
+// behaviour are unchanged, while tests can substitute an in-memory fake.
+type chConn interface {
+	PrepareBatch(ctx context.Context, query string, opts ...driver.PrepareBatchOption) (driver.Batch, error)
+	Close() error
+}

--- a/exporter/gigapipeexporter/docs/schema.md
+++ b/exporter/gigapipeexporter/docs/schema.md
@@ -1,0 +1,65 @@
+# Schema model, and how this differs from `clickhouseexporter`
+
+The OpenTelemetry Collector already ships a generic
+[`clickhouseexporter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter).
+This exporter is not a competitor to it — it targets a different schema for a
+different query surface. This page explains that schema and when each exporter
+is the right choice.
+
+## Two different goals
+
+| | `clickhouseexporter` (contrib) | `gigapipeexporter` (this component) |
+| --- | --- | --- |
+| Table model | Generic OTel tables (`otel_logs`, `otel_traces`, `otel_metrics_*`) | Gigapipe/qryn polyglot schema (`samples_v3`, `time_series`, `tempo_traces`, `tempo_traces_attrs_gin`) |
+| Intended reader | ClickHouse SQL / Grafana ClickHouse plugin | The Loki, Prometheus, Tempo and Pyroscope APIs served by [Gigapipe](https://github.com/metrico/gigapipe) |
+| Series identity | Row columns | A Loki-style **fingerprint** over the label set |
+| Metric naming | OTel metric names | Prometheus-compliant names + labels (`__name__`) |
+
+If you query ClickHouse directly, `clickhouseexporter` is the natural fit. If you
+run Gigapipe and want the same data to answer LogQL, PromQL, Tempo and Pyroscope
+queries, you need this schema — it is not reproducible with the generic tables.
+
+## The fingerprint model (logs and metrics)
+
+Logs and metrics are both written as two joined tables:
+
+- **`samples_v3`** — one row per data point: `fingerprint`, `timestamp_ns`,
+  `value`, `string`, `type` (`1` = log, `2` = metric).
+- **`time_series`** — one row per unique series: `fingerprint`, `labels` (JSON),
+  `name`, `type`.
+
+The **fingerprint** is a hash of the label set. It is the join key between a
+sample and its series, exactly as in Loki/Prometheus on ClickHouse. Identical
+label sets share a fingerprint; any difference produces a new one. This is what
+makes the data addressable as streams/series by LogQL and PromQL.
+
+- **Metrics** are normalised to the Prometheus data model: metric names are made
+  Prometheus-compliant (e.g. `http.server.duration` → `http_server_duration`),
+  the name is carried in the `__name__` label, and `service.name`/
+  `service.namespace`/`service.instance.id` map to `job`/`instance`.
+- **Logs** promote attributes to labels following Loki semantics — see
+  [Logs: attributes vs. labels](logs-labels.md).
+
+## The Tempo model (traces)
+
+Traces have two write paths:
+
+- **Server-side (default single node):** `traces_input` (a `Null`-engine ingest
+  table) receiving span rows with an OTLP payload.
+- **Client-side (`client_side_trace_processing: true`, clustered):** the span is
+  split across **two** tables in one batch:
+  - `tempo_traces` — the trace/span rows with the OTLP payload
+    (`json` or `proto`, per `trace_payload_type`).
+  - `tempo_traces_attrs_gin` — one row per tag, forming the GIN tag index Tempo
+    search relies on.
+
+The generic exporter writes a single flat traces table with no equivalent tag
+index, so Tempo-style tag search is not available from it.
+
+## Executable contract
+
+These schema guarantees are pinned by characterization tests in
+[`schema_contract_test.go`](../schema_contract_test.go): the fingerprint join,
+the Prometheus read model, the Tempo two-table split, and Loki label promotion.
+They exist so the distinction from `clickhouseexporter` is verifiable, not just
+described.

--- a/exporter/gigapipeexporter/factory_test.go
+++ b/exporter/gigapipeexporter/factory_test.go
@@ -40,6 +40,27 @@ func createLogsWithObserver(t *testing.T, factory exporter.Factory) *observer.Ob
 	return logs
 }
 
+// TestFactoryCreateAllSignals exercises the three create funcs (and thus the
+// exporter constructors + initMetrics) end to end with the default config.
+// clickhouse.Open is lazy, so no live server is required.
+func TestFactoryCreateAllSignals(t *testing.T) {
+	factory := NewFactory()
+	set := exportertest.NewNopSettings(factory.Type())
+	cfg := factory.CreateDefaultConfig()
+
+	tr, err := factory.CreateTraces(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, tr.Shutdown(context.Background()))
+
+	lg, err := factory.CreateLogs(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, lg.Shutdown(context.Background()))
+
+	me, err := factory.CreateMetrics(context.Background(), set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, me.Shutdown(context.Background()))
+}
+
 // TestQrynAliasLogsDeprecationWarning verifies the deprecated "qryn" factory
 // logs a deprecation warning on use, and the "gigapipe" factory does not.
 func TestQrynAliasLogsDeprecationWarning(t *testing.T) {

--- a/exporter/gigapipeexporter/logs.go
+++ b/exporter/gigapipeexporter/logs.go
@@ -34,7 +34,7 @@ type logsExporter struct {
 	logger *zap.Logger
 	meter  metric.Meter
 
-	db clickhouse.Conn
+	db chConn
 
 	attributeLabels      string
 	resourceLabels       string
@@ -501,7 +501,7 @@ func (e *logsExporter) buildSamplesAndTimeSeries(ld plog.Logs) ([]Sample, []Time
 	return samples, timeSeries, nil
 }
 
-func batchSamplesAndTimeSeries(ctx context.Context, logger *zap.Logger, db clickhouse.Conn, samples []Sample, timeSeries []TimeSerie) error {
+func batchSamplesAndTimeSeries(ctx context.Context, logger *zap.Logger, db chConn, samples []Sample, timeSeries []TimeSerie) error {
 	// The caller injects the cluster flag via clusterKey. A missing flag can only
 	// mean a context-propagation bug (see #109). Degrading to non-clustered would
 	// steer inserts at the wrong schema and fail anyway, so treat it as a hard

--- a/exporter/gigapipeexporter/logs_push_test.go
+++ b/exporter/gigapipeexporter/logs_push_test.go
@@ -1,0 +1,111 @@
+package gigapipeexporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+func TestPushLogsData_SingleNode(t *testing.T) {
+	fc := &fakeConn{}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: formatRaw}
+
+	require.NoError(t, e.pushLogsData(context.Background(), newLogs("hello", plog.SeverityNumberInfo)))
+
+	require.Len(t, fc.queries, 2)
+	joined := strings.Join(fc.queries, "\n")
+	assert.Contains(t, joined, "samples_v3")
+	assert.Contains(t, joined, "time_series")
+	require.Len(t, fc.batches, 2)
+	assert.True(t, fc.batches[0].sent)
+	assert.True(t, fc.batches[1].sent)
+	// one sample row appended for the single log record
+	require.Len(t, fc.batches[0].appended, 1)
+	_, ok := fc.batches[0].appended[0].(*Sample)
+	assert.True(t, ok)
+}
+
+func TestPushLogsData_PrepareBatchError(t *testing.T) {
+	fc := &fakeConn{prepareErr: errFakePrepare}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: formatRaw}
+	err := e.pushLogsData(context.Background(), newLogs("x", plog.SeverityNumberInfo))
+	require.ErrorIs(t, err, errFakePrepare)
+}
+
+func TestPushLogsData_SendError(t *testing.T) {
+	fc := &fakeConn{sendErr: errFakeSend}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: formatRaw}
+	err := e.pushLogsData(context.Background(), newLogs("x", plog.SeverityNumberInfo))
+	require.ErrorIs(t, err, errFakeSend)
+}
+
+func TestPushLogsData_TimeSeriesBatchError(t *testing.T) {
+	fc := &fakeConn{prepareFailOn: "time_series"}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: formatRaw}
+	err := e.pushLogsData(context.Background(), newLogs("x", plog.SeverityNumberInfo))
+	require.ErrorIs(t, err, errFakePrepare)
+}
+
+func TestPushLogsData_InvalidFormatErrors(t *testing.T) {
+	fc := &fakeConn{}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: "bogus"}
+	err := e.pushLogsData(context.Background(), newLogs("x", plog.SeverityNumberInfo))
+	require.Error(t, err)
+	// conversion fails before any batch is prepared
+	assert.Empty(t, fc.queries)
+}
+
+func TestConvertLogToLine_JSONMapBody(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetEmptyMap().PutStr("k", "v")
+	log.SetSeverityText("INFO")
+	log.Attributes().PutStr("a", "b")
+	res := newLogs("x", plog.SeverityNumberInfo).ResourceLogs().At(0).Resource()
+
+	line, err := convertLogToLine(log, res, formatJSON)
+	require.NoError(t, err)
+	assert.Contains(t, line, `"k":"v"`)
+	assert.Contains(t, line, `"severity":"INFO"`)
+}
+
+func TestConvertLogToLine_LogfmtRichBody(t *testing.T) {
+	log := plog.NewLogRecord()
+	body := log.Body().SetEmptyMap()
+	body.PutStr("msg", "hello")
+	body.PutInt("n", 3)
+	body.PutBool("ok", true)
+	body.PutDouble("f", 1.5)
+	body.PutEmptySlice("s").AppendEmpty().SetStr("e0")
+	log.SetTraceID([16]byte{1})
+	log.SetSpanID([8]byte{2})
+	log.SetSeverityText("WARN")
+	log.Attributes().PutStr("attr", "av")
+	res := newLogs("x", plog.SeverityNumberInfo).ResourceLogs().At(0).Resource()
+
+	line, err := convertLogToLine(log, res, formatLogfmt)
+	require.NoError(t, err)
+	assert.Contains(t, line, "msg=hello")
+	assert.Contains(t, line, "traceID=")
+	assert.Contains(t, line, "severity=WARN")
+	assert.Contains(t, line, "attribute_attr=av")
+}
+
+func TestPushLogsData_LogfmtFormat(t *testing.T) {
+	fc := &fakeConn{}
+	e := &logsExporter{logger: zap.NewNop(), db: fc, format: formatLogfmt}
+	require.NoError(t, e.pushLogsData(context.Background(), newLogs("level=info msg=hi", plog.SeverityNumberInfo)))
+	require.Len(t, fc.batches, 2)
+	assert.True(t, fc.batches[0].sent)
+}
+
+func TestLogsShutdownClosesConn(t *testing.T) {
+	fc := &fakeConn{}
+	e := &logsExporter{db: fc}
+	require.NoError(t, e.Shutdown(context.Background()))
+	assert.True(t, fc.closed)
+}

--- a/exporter/gigapipeexporter/metrics.go
+++ b/exporter/gigapipeexporter/metrics.go
@@ -31,7 +31,7 @@ type metricsExporter struct {
 	logger *zap.Logger
 	meter  metric.Meter
 
-	db clickhouse.Conn
+	db chConn
 
 	namespace string
 	cluster   bool

--- a/exporter/gigapipeexporter/metrics_test.go
+++ b/exporter/gigapipeexporter/metrics_test.go
@@ -1,0 +1,234 @@
+package gigapipeexporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func TestRemovePromForbiddenRunes(t *testing.T) {
+	assert.Equal(t, "a_b_c", removePromForbiddenRunes("a.b-c"))
+	assert.Equal(t, "keep_it", removePromForbiddenRunes("keep_it"))
+}
+
+func TestNormalizeLabel(t *testing.T) {
+	assert.Equal(t, "", normalizeLabel(""))
+	assert.Equal(t, "a_b", normalizeLabel("a.b"))
+	assert.Equal(t, "key_1abc", normalizeLabel("1abc")) // leading digit
+	assert.Equal(t, "key_x", normalizeLabel("_x"))      // single leading underscore
+	assert.Equal(t, "__x", normalizeLabel("__x"))       // double underscore preserved
+}
+
+func TestBuildPromCompliantName(t *testing.T) {
+	m := pmetric.NewMetric()
+	m.SetName("my.metric")
+	assert.Equal(t, "my_metric", buildPromCompliantName(m, ""))
+	assert.Equal(t, "ns_my_metric", buildPromCompliantName(m, "ns"))
+
+	d := pmetric.NewMetric()
+	d.SetName("5xx")
+	assert.Equal(t, "_5xx", buildPromCompliantName(d, "")) // leading digit prefixed
+}
+
+func TestBuildLabelSet_JobInstanceAndExtras(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(attrServiceName, "svc")
+	res.Attributes().PutStr(attrServiceNamespace, "ns")
+	res.Attributes().PutStr(attrServiceInstanceID, "inst-1")
+
+	attrs := pcommon.NewMap()
+	attrs.PutStr("http.method", "GET")
+
+	ls := buildLabelSet(res, attrs, model.MetricNameLabel, "m", "__internal__", "keep")
+
+	assert.Equal(t, model.LabelValue("ns/svc"), ls[model.JobLabel])
+	assert.Equal(t, model.LabelValue("inst-1"), ls[model.InstanceLabel])
+	assert.Equal(t, model.LabelValue("GET"), ls["http_method"])
+	assert.Equal(t, model.LabelValue("m"), ls[model.MetricNameLabel])
+	assert.Equal(t, model.LabelValue("keep"), ls["__internal__"]) // internal label kept verbatim
+}
+
+func TestIsValidAggregationTemporality(t *testing.T) {
+	gauge := pmetric.NewMetric()
+	gauge.SetEmptyGauge()
+	assert.True(t, isValidAggregationTemporality(gauge))
+
+	summary := pmetric.NewMetric()
+	summary.SetEmptySummary()
+	assert.True(t, isValidAggregationTemporality(summary))
+
+	sumCumulative := pmetric.NewMetric()
+	sumCumulative.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	assert.True(t, isValidAggregationTemporality(sumCumulative))
+
+	sumDelta := pmetric.NewMetric()
+	sumDelta.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	assert.False(t, isValidAggregationTemporality(sumDelta))
+
+	histDelta := pmetric.NewMetric()
+	histDelta.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	assert.False(t, isValidAggregationTemporality(histDelta))
+}
+
+func TestExportNumberDataPoint_GaugeIntAndDouble(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("g")
+
+	dpDouble := pmetric.NewNumberDataPoint()
+	dpDouble.SetDoubleValue(1.5)
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.exportNumberDataPoint(dpDouble, res, m, &samples, &ts))
+	require.Len(t, samples, 1)
+	assert.Equal(t, 1.5, samples[0].Value)
+	assert.Equal(t, int8(SAMPLE_TYPE_METRIC), samples[0].Type)
+	require.Len(t, ts, 1)
+
+	dpInt := pmetric.NewNumberDataPoint()
+	dpInt.SetIntValue(4)
+	samples = nil
+	ts = nil
+	require.NoError(t, e.exportNumberDataPoint(dpInt, res, m, &samples, &ts))
+	assert.Equal(t, float64(4), samples[0].Value)
+}
+
+func TestExportHistogramDataPoint(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("h")
+	dp := pmetric.NewHistogramDataPoint()
+	dp.SetCount(10)
+	dp.SetSum(42)
+	dp.ExplicitBounds().FromRaw([]float64{1, 5})
+	dp.BucketCounts().FromRaw([]uint64{3, 4, 3})
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.exportHistogramDataPoint(dp, res, m, &samples, &ts))
+
+	// sum + count + 2 explicit buckets + +Inf bucket = 5 samples
+	assert.Len(t, samples, 5)
+	assert.NotEmpty(t, ts)
+}
+
+func TestExportSummaryDataPoint(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("s")
+	dp := pmetric.NewSummaryDataPoint()
+	dp.SetCount(2)
+	dp.SetSum(10)
+	q := dp.QuantileValues().AppendEmpty()
+	q.SetQuantile(0.99)
+	q.SetValue(7)
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.exportSummaryDataPoint(dp, res, m, &samples, &ts))
+
+	// sum + count + 1 quantile = 3 samples
+	assert.Len(t, samples, 3)
+	assert.NotEmpty(t, ts)
+}
+
+func TestCollectFromMetric_SkipsInvalidTemporality(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("d")
+	m.SetEmptySum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	m.Sum().DataPoints().AppendEmpty().SetIntValue(1)
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.collectFromMetric(m, res, &samples, &ts))
+	assert.Empty(t, samples)
+	assert.Empty(t, ts)
+}
+
+func TestCollectFromMetrics_AllTypes(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	ms := pmetric.NewMetricSlice()
+
+	gauge := ms.AppendEmpty()
+	gauge.SetName("g")
+	gauge.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(1)
+
+	sum := ms.AppendEmpty()
+	sum.SetName("c")
+	s := sum.SetEmptySum()
+	s.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	s.DataPoints().AppendEmpty().SetIntValue(2)
+
+	hist := ms.AppendEmpty()
+	hist.SetName("h")
+	h := hist.SetEmptyHistogram()
+	h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	hdp := h.DataPoints().AppendEmpty()
+	hdp.SetCount(3)
+	hdp.SetSum(9)
+	hdp.ExplicitBounds().FromRaw([]float64{1})
+	hdp.BucketCounts().FromRaw([]uint64{1, 2})
+
+	summary := ms.AppendEmpty()
+	summary.SetName("s")
+	sdp := summary.SetEmptySummary().DataPoints().AppendEmpty()
+	sdp.SetCount(1)
+	sdp.SetSum(4)
+	sdp.QuantileValues().AppendEmpty().SetValue(4)
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.collectFromMetrics(ms, res, &samples, &ts))
+	assert.NotEmpty(t, samples)
+	assert.NotEmpty(t, ts)
+}
+
+func TestPushMetricsData_SingleNode(t *testing.T) {
+	fc := &fakeConn{}
+	e := &metricsExporter{logger: zap.NewNop(), db: fc}
+
+	require.NoError(t, e.pushMetricsData(context.Background(), newGaugeMetrics("g", 3)))
+
+	require.Len(t, fc.queries, 2)
+	joined := strings.Join(fc.queries, "\n")
+	assert.Contains(t, joined, "samples_v3")
+	assert.Contains(t, joined, "time_series")
+	require.Len(t, fc.batches, 2)
+	assert.True(t, fc.batches[0].sent)
+	assert.True(t, fc.batches[1].sent)
+}
+
+func TestPushMetricsData_PrepareBatchError(t *testing.T) {
+	fc := &fakeConn{prepareErr: errFakePrepare}
+	e := &metricsExporter{logger: zap.NewNop(), db: fc}
+	err := e.pushMetricsData(context.Background(), newGaugeMetrics("g", 1))
+	require.ErrorIs(t, err, errFakePrepare)
+}
+
+func TestPushMetricsData_TimeSeriesBatchError(t *testing.T) {
+	// fail only the second (time_series) PrepareBatch to cover that branch
+	fc := &fakeConn{prepareFailOn: "time_series"}
+	e := &metricsExporter{logger: zap.NewNop(), db: fc}
+	err := e.pushMetricsData(context.Background(), newGaugeMetrics("g", 1))
+	require.ErrorIs(t, err, errFakePrepare)
+}
+
+func TestMetricsShutdownClosesConn(t *testing.T) {
+	fc := &fakeConn{}
+	e := &metricsExporter{db: fc}
+	require.NoError(t, e.Shutdown(context.Background()))
+	assert.True(t, fc.closed)
+}

--- a/exporter/gigapipeexporter/schema_contract_test.go
+++ b/exporter/gigapipeexporter/schema_contract_test.go
@@ -1,0 +1,141 @@
+package gigapipeexporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+// The tests in this file are characterization tests for the Gigapipe (formerly
+// qryn) polyglot schema. They exist to document, in executable form, what makes
+// this exporter distinct from the generic contrib `clickhouseexporter`:
+//
+//   - clickhouseexporter writes a generic OTel table model (otel_logs,
+//     otel_traces, otel_metrics_*), designed to be queried as ClickHouse tables.
+//   - this exporter writes the Gigapipe fingerprint schema (samples_v3 +
+//     time_series keyed by a Loki-style label fingerprint; tempo_traces +
+//     tempo_traces_attrs_gin; Prometheus-compliant metric names/labels) so the
+//     same ClickHouse instance is queryable through the Loki, Prometheus, Tempo
+//     and Pyroscope APIs.
+//
+// They intentionally assert the schema contract (table names, the fingerprint
+// join, the Prometheus read model, the Tempo two-table split), not just that the
+// code runs — that contract is the justification for the component existing
+// alongside clickhouseexporter.
+
+// TestSchemaContract_FingerprintLinksSamplesToTimeSeries pins the Loki fingerprint
+// model: every Sample shares a fingerprint with its TimeSerie (that is the join
+// key between samples_v3 and time_series), and distinct label sets get distinct
+// fingerprints. clickhouseexporter has no fingerprint concept.
+func TestSchemaContract_FingerprintLinksSamplesToTimeSeries(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("requests")
+
+	dpA := pmetric.NewNumberDataPoint()
+	dpA.SetDoubleValue(1)
+	dpA.Attributes().PutStr("route", "/a")
+
+	dpB := pmetric.NewNumberDataPoint()
+	dpB.SetDoubleValue(1)
+	dpB.Attributes().PutStr("route", "/b")
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.exportNumberDataPoint(dpA, res, m, &samples, &ts))
+	require.NoError(t, e.exportNumberDataPoint(dpB, res, m, &samples, &ts))
+
+	require.Len(t, samples, 2)
+	require.Len(t, ts, 2)
+	// sample[i] and timeSeries[i] are joined by fingerprint
+	assert.Equal(t, samples[0].Fingerprint, ts[0].Fingerprint)
+	assert.Equal(t, samples[1].Fingerprint, ts[1].Fingerprint)
+	// different label sets -> different fingerprints (no collision on the join key)
+	assert.NotEqual(t, samples[0].Fingerprint, samples[1].Fingerprint)
+}
+
+// TestSchemaContract_MetricsProducePrometheusReadModel asserts metrics are written
+// as a Prometheus-readable series: the __name__ label carries the
+// Prom-normalised metric name and the row Type marks it as a metric sample. This
+// is what lets PromQL read the data back through Gigapipe.
+func TestSchemaContract_MetricsProducePrometheusReadModel(t *testing.T) {
+	e := &metricsExporter{}
+	res := pcommon.NewResource()
+	m := pmetric.NewMetric()
+	m.SetName("http.server.duration") // dotted OTel name
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetDoubleValue(1)
+
+	var samples []Sample
+	var ts []TimeSerie
+	require.NoError(t, e.exportNumberDataPoint(dp, res, m, &samples, &ts))
+
+	require.Len(t, ts, 1)
+	// the labels JSON is the Prometheus label set, keyed by __name__
+	assert.Contains(t, ts[0].Labels, `"`+model.MetricNameLabel+`"`)
+	// name is Prom-normalised (dots -> underscores)
+	assert.Equal(t, "http_server_duration", ts[0].Name)
+	assert.Equal(t, int8(SAMPLE_TYPE_METRIC), samples[0].Type)
+}
+
+// TestSchemaContract_TracesProduceTempoModel pins the Tempo-compatible two-table
+// write: client-side processing inserts into tempo_traces AND
+// tempo_traces_attrs_gin (the GIN tag index Tempo search relies on), with the
+// span payload stored as OTLP. clickhouseexporter writes a single flat traces
+// table with no such tag index.
+func TestSchemaContract_TracesProduceTempoModel(t *testing.T) {
+	fc := &fakeConn{}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, cluster: true, clientSide: true, tracePayloadType: "json"}
+
+	require.NoError(t, e.pushTraceData(context.Background(), newTraces()))
+
+	joined := strings.Join(fc.queries, "\n")
+	assert.Contains(t, joined, "tempo_traces")
+	assert.Contains(t, joined, "tempo_traces_attrs_gin")
+
+	require.Len(t, fc.batches, 2)
+	// batch 0: the trace rows; batch 1: the GIN tag-index rows
+	require.NotEmpty(t, fc.batches[0].appended)
+	_, ok := fc.batches[0].appended[0].(*TempoTrace)
+	assert.True(t, ok)
+	require.NotEmpty(t, fc.batches[1].appended)
+	for _, row := range fc.batches[1].appended {
+		_, ok := row.(*TempoTraceTag)
+		assert.True(t, ok, "attrs_gin batch must hold TempoTraceTag rows")
+	}
+}
+
+// TestSchemaContract_LokiLabelPromotion documents the Loki ingestion semantics
+// this exporter implements and clickhouseexporter does not: the level label is
+// always promoted, resource attributes are promoted by default, and
+// high-cardinality log-record attributes are held back unless explicitly opted
+// in. This is what makes the resulting stream queryable as Loki labels.
+func TestSchemaContract_LokiLabelPromotion(t *testing.T) {
+	exp := &logsExporter{} // defaults: promoteAllAttributes off
+
+	logAttrs := pcommon.NewMap()
+	logAttrs.PutStr("high.cardinality.id", "req-123")
+
+	resAttrs := pcommon.NewMap()
+	resAttrs.PutStr("service.instance", "pod-1")
+
+	log := newLogRecord(plog.SeverityNumberWarn)
+	logAttrs.CopyTo(log.Attributes())
+	addLogLevelAttributeAndHint(log)
+
+	labels := exp.convertAttributesAndMerge(log.Attributes(), resAttrs)
+
+	assert.Equal(t, model.LabelValue("WARN"), labels["level"], "level is always promoted")
+	assert.Equal(t, model.LabelValue("pod-1"), labels["service.instance"], "resource attrs promoted by default")
+	assert.NotContains(t, labels, "high.cardinality.id", "log attrs held back to protect label cardinality")
+}

--- a/exporter/gigapipeexporter/schema_test.go
+++ b/exporter/gigapipeexporter/schema_test.go
@@ -1,0 +1,51 @@
+package gigapipeexporter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSQLBuilders_ClusterSuffix verifies each INSERT builder targets the base
+// table on a single node and the _dist table when clustered.
+func TestSQLBuilders_ClusterSuffix(t *testing.T) {
+	tests := []struct {
+		name      string
+		build     func(bool) string
+		baseTable string
+	}{
+		{"samples", samplesSQL, "samples_v3"},
+		{"time_series", TimeSerieSQL, "time_series"},
+		{"tempo_traces", TracesV2InputSQL, "tempo_traces"},
+		{"tempo_traces_attrs_gin", TracesTagsV2InputSQL, "tempo_traces_attrs_gin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			single := tt.build(false)
+			clustered := tt.build(true)
+
+			assert.Contains(t, single, "INSERT INTO "+tt.baseTable)
+			assert.NotContains(t, single, tt.baseTable+"_dist")
+
+			assert.Contains(t, clustered, "INSERT INTO "+tt.baseTable+"_dist")
+		})
+	}
+}
+
+// TestTracesInputSQL_NoClusterSuffix documents that the v1 traces_input builder
+// ignores the cluster flag (it always targets the same Null-engine table).
+func TestTracesInputSQL_NoClusterSuffix(t *testing.T) {
+	assert.Equal(t, tracesInputSQL(false), tracesInputSQL(true))
+	assert.Contains(t, tracesInputSQL(true), "INSERT INTO traces_input")
+	assert.NotContains(t, tracesInputSQL(true), "_dist")
+}
+
+// TestSamplesSQL_Columns guards the samples_v3 column list the AppendStruct tags
+// must line up with.
+func TestSamplesSQL_Columns(t *testing.T) {
+	sql := samplesSQL(false)
+	for _, col := range []string{"fingerprint", "timestamp_ns", "value", "string", "`type`"} {
+		assert.True(t, strings.Contains(sql, col), "samples SQL missing column %q", col)
+	}
+}

--- a/exporter/gigapipeexporter/testsupport_test.go
+++ b/exporter/gigapipeexporter/testsupport_test.go
@@ -1,0 +1,166 @@
+package gigapipeexporter
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// errFakePrepare / errFakeSend / errFakeAppend are sentinels the tests inject to
+// exercise error-propagation paths without a real ClickHouse connection.
+var (
+	errFakePrepare = errors.New("fake prepare batch error")
+	errFakeSend    = errors.New("fake send error")
+	errFakeAppend  = errors.New("fake append error")
+)
+
+// fakeConn is an in-memory chConn. It records the queries it was asked to
+// prepare and hands out fakeBatch values, optionally injecting errors so the
+// exporters' failure branches can be tested.
+type fakeConn struct {
+	queries []string
+	batches []*fakeBatch
+	closed  bool
+
+	// prepareErr, when set, makes every PrepareBatch return it.
+	prepareErr error
+	// prepareFailOn, when non-empty, makes PrepareBatch fail (with errFakePrepare)
+	// only for queries containing this substring, so a specific batch of a
+	// multi-batch push can be failed selectively.
+	prepareFailOn string
+	// appendErr / sendErr are propagated into every batch this conn creates.
+	appendErr error
+	sendErr   error
+}
+
+func (c *fakeConn) PrepareBatch(_ context.Context, query string, _ ...driver.PrepareBatchOption) (driver.Batch, error) {
+	c.queries = append(c.queries, query)
+	if c.prepareErr != nil {
+		return nil, c.prepareErr
+	}
+	if c.prepareFailOn != "" && strings.Contains(query, c.prepareFailOn) {
+		return nil, errFakePrepare
+	}
+	b := &fakeBatch{appendErr: c.appendErr, sendErr: c.sendErr}
+	c.batches = append(c.batches, b)
+	return b, nil
+}
+
+func (c *fakeConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+// fakeBatch is an in-memory driver.Batch. It records appended structs and the
+// terminal call (Send/Abort) so tests can assert what the exporter produced.
+type fakeBatch struct {
+	appended []any
+	sent     bool
+	aborted  bool
+	flushed  int
+	closed   bool
+
+	appendErr error
+	sendErr   error
+	abortErr  error
+}
+
+func (b *fakeBatch) Abort() error {
+	b.aborted = true
+	return b.abortErr
+}
+
+func (b *fakeBatch) Append(v ...any) error {
+	if b.appendErr != nil {
+		return b.appendErr
+	}
+	b.appended = append(b.appended, v...)
+	return nil
+}
+
+func (b *fakeBatch) AppendStruct(v any) error {
+	if b.appendErr != nil {
+		return b.appendErr
+	}
+	b.appended = append(b.appended, v)
+	return nil
+}
+
+func (b *fakeBatch) Column(int) driver.BatchColumn { return nil }
+
+func (b *fakeBatch) Flush() error {
+	b.flushed++
+	return nil
+}
+
+func (b *fakeBatch) Send() error {
+	if b.sendErr != nil {
+		return b.sendErr
+	}
+	b.sent = true
+	return nil
+}
+
+func (b *fakeBatch) IsSent() bool                { return b.sent }
+func (b *fakeBatch) Rows() int                   { return len(b.appended) }
+func (b *fakeBatch) Columns() []column.Interface { return nil }
+
+func (b *fakeBatch) Close() error {
+	b.closed = true
+	return nil
+}
+
+// --- pdata fixture helpers -------------------------------------------------
+
+// newLogs builds a plog.Logs with a single record carrying the given body and
+// severity, under one resource attribute (service.name).
+func newLogs(body string, severity plog.SeverityNumber) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr(attrServiceName, "test-service")
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.Body().SetStr(body)
+	lr.SetSeverityNumber(severity)
+	return ld
+}
+
+// newTraces builds a ptrace.Traces with a single span under one resource
+// (service.name) and instrumentation scope.
+func newTraces() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr(attrServiceName, "test-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("test-scope")
+	ss.Scope().SetVersion("v1.2.3")
+	span := ss.Spans().AppendEmpty()
+	span.SetName("test-span")
+	span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	span.SetParentSpanID(pcommon.SpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1}))
+	span.SetStartTimestamp(pcommon.Timestamp(1_000_000_000))
+	span.SetEndTimestamp(pcommon.Timestamp(2_000_000_000))
+	span.Attributes().PutStr("span.attr", "v")
+	return td
+}
+
+// newGaugeMetrics builds a pmetric.Metrics with a single gauge data point.
+func newGaugeMetrics(name string, value float64) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr(attrServiceName, "test-service")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(value)
+	dp.SetTimestamp(pcommon.Timestamp(1_000_000_000))
+	dp.Attributes().PutStr("dp.attr", "v")
+	return md
+}

--- a/exporter/gigapipeexporter/trace_batch_processor_test.go
+++ b/exporter/gigapipeexporter/trace_batch_processor_test.go
@@ -1,0 +1,70 @@
+package gigapipeexporter
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnhexAndPad(t *testing.T) {
+	// shorter than size: left-padded with zeros to the target width
+	out, err := unhexAndPad("0102", 8)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 1, 2}, out)
+
+	// exact width: unchanged
+	full := "0102030405060708"
+	out, err = unhexAndPad(full, 8)
+	require.NoError(t, err)
+	want, _ := hex.DecodeString(full)
+	assert.Equal(t, want, out)
+
+	// invalid hex: error
+	_, err = unhexAndPad("zz", 8)
+	require.Error(t, err)
+}
+
+func TestTraceWithTagsBatch_AppendStructSplitsTraceAndTags(t *testing.T) {
+	main := &fakeBatch{}
+	tags := &fakeBatch{}
+	b := &traceWithTagsBatch{Batch: main, tagsBatch: tags}
+
+	ti := &TraceInput{
+		TraceID:  "0102030405060708090a0b0c0d0e0f10",
+		SpanID:   "0102030405060708",
+		ParentID: "0807060504030201",
+		Name:     "span",
+		Tags:     [][]string{{"k1", "v1"}, {"k2", "v2"}},
+	}
+	require.NoError(t, b.AppendStruct(ti))
+
+	require.Len(t, main.appended, 1)
+	_, ok := main.appended[0].(*TempoTrace)
+	assert.True(t, ok)
+	// one tag row per tag pair
+	require.Len(t, tags.appended, 2)
+	_, ok = tags.appended[0].(*TempoTraceTag)
+	assert.True(t, ok)
+}
+
+func TestTraceWithTagsBatch_AppendStructWrongType(t *testing.T) {
+	b := &traceWithTagsBatch{Batch: &fakeBatch{}, tagsBatch: &fakeBatch{}}
+	err := b.AppendStruct("not a trace")
+	require.Error(t, err)
+}
+
+func TestTraceWithTagsBatch_SendAndAbort(t *testing.T) {
+	main := &fakeBatch{}
+	tags := &fakeBatch{}
+	b := &traceWithTagsBatch{Batch: main, tagsBatch: tags}
+
+	require.NoError(t, b.Send())
+	assert.True(t, main.sent)
+	assert.True(t, tags.sent)
+
+	require.NoError(t, b.Abort())
+	assert.True(t, main.aborted)
+	assert.True(t, tags.aborted)
+}

--- a/exporter/gigapipeexporter/traces.go
+++ b/exporter/gigapipeexporter/traces.go
@@ -51,7 +51,7 @@ type tracesExporter struct {
 	logger *zap.Logger
 	meter  metric.Meter
 
-	db               clickhouse.Conn
+	db               chConn
 	cluster          bool
 	clientSide       bool
 	tracePayloadType string

--- a/exporter/gigapipeexporter/traces_test.go
+++ b/exporter/gigapipeexporter/traces_test.go
@@ -1,0 +1,247 @@
+package gigapipeexporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestAttributeMapToStringMap(t *testing.T) {
+	m := pcommon.NewMap()
+	m.PutStr("s", "str")
+	m.PutInt("i", 7)
+	m.PutBool("b", true)
+
+	out := attributeMapToStringMap(m)
+
+	assert.Equal(t, "str", out["s"])
+	assert.Equal(t, "7", out["i"])
+	assert.Equal(t, "true", out["b"])
+}
+
+func TestAggregateSpanTags_SpanOverridesBase(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("k", "span")
+	span.Attributes().PutStr("only.span", "x")
+
+	base := map[string]string{"k": "base", "only.base": "y"}
+
+	tags := aggregateSpanTags(span, base)
+
+	assert.Equal(t, "span", tags["k"]) // span attr wins over base
+	assert.Equal(t, "x", tags["only.span"])
+	assert.Equal(t, "y", tags["only.base"])
+	// base map is not mutated
+	assert.Equal(t, "base", base["k"])
+}
+
+func TestExtractScopeTags(t *testing.T) {
+	scope := pcommon.NewInstrumentationScope()
+	scope.SetName("lib")
+	scope.SetVersion("2.0")
+
+	tags := map[string]string{}
+	extractScopeTags(scope, tags)
+
+	assert.Equal(t, "lib", tags[attrOTelLibraryName])
+	assert.Equal(t, "2.0", tags[attrOTelLibraryVersion])
+
+	// empty scope adds nothing
+	empty := map[string]string{}
+	extractScopeTags(pcommon.NewInstrumentationScope(), empty)
+	assert.Empty(t, empty)
+}
+
+func TestSpanLinksToTags(t *testing.T) {
+	span := ptrace.NewSpan()
+	link := span.Links().AppendEmpty()
+	link.SetTraceID(pcommon.TraceID([16]byte{1}))
+	link.SetSpanID(pcommon.SpanID([8]byte{2}))
+	link.Attributes().PutStr("lk", "lv")
+
+	tags := map[string]string{}
+	require.NoError(t, spanLinksToTags(span.Links(), tags))
+
+	v, ok := tags["otlp.link.0"]
+	require.True(t, ok)
+	assert.Contains(t, v, link.TraceID().String())
+	assert.Contains(t, v, `{"lk":"lv"}`)
+}
+
+func TestResourceToServiceNameAndAttributeMap(t *testing.T) {
+	// no attributes -> sentinel service name
+	empty := pcommon.NewResource()
+	name, tags := resourceToServiceNameAndAttributeMap(empty)
+	assert.Equal(t, "OTLPResourceNoServiceName", name)
+	assert.Empty(t, tags)
+
+	// service.name present
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(attrServiceName, "svc")
+	name, tags = resourceToServiceNameAndAttributeMap(res)
+	assert.Equal(t, "svc", name)
+	assert.Equal(t, "svc", tags[attrServiceName])
+}
+
+func TestExtractServiceName_Fallbacks(t *testing.T) {
+	assert.Equal(t, "svc", extractServiceName(map[string]string{attrServiceName: "svc"}))
+	assert.Equal(t, "faas", extractServiceName(map[string]string{attrFaaSName: "faas"}))
+	assert.Equal(t, "dep", extractServiceName(map[string]string{attrK8SDeploymentName: "dep"}))
+	assert.Equal(t, "proc", extractServiceName(map[string]string{attrProcessExecutableName: "proc"}))
+	assert.Equal(t, "OTLPResourceNoServiceName", extractServiceName(map[string]string{}))
+}
+
+func TestEnsureUTF8(t *testing.T) {
+	assert.Equal(t, "ok", ensureUTF8("ok"))
+	assert.Contains(t, ensureUTF8("\xff\xfe"), "invalid utf-8")
+}
+
+func TestConvertTracesInput_JSONAndProto(t *testing.T) {
+	span := newTraces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+
+	for _, payloadType := range []string{"json", "proto"} {
+		t.Run(payloadType, func(t *testing.T) {
+			ti, err := convertTracesInput(span, pcommon.NewResource(), "svc", map[string]string{}, payloadType)
+			require.NoError(t, err)
+			assert.Equal(t, span.TraceID().String(), ti.TraceID)
+			assert.Equal(t, span.SpanID().String(), ti.SpanID)
+			assert.Equal(t, "svc", ti.ServiceName)
+			assert.Equal(t, int8(2), ti.PayloadType)
+			assert.NotEmpty(t, ti.Payload)
+			// service.name / name are injected into tags
+			foundName := false
+			for _, kv := range ti.Tags {
+				if kv[0] == "service.name" {
+					foundName = true
+					assert.Equal(t, "svc", kv[1])
+				}
+			}
+			assert.True(t, foundName)
+		})
+	}
+}
+
+// TestConvertTracesInput_RichSpanPayload drives marshalSpan over span events and
+// links whose attributes span every pcommon value type, covering the OTLP
+// conversion helpers (valueToOtlpAnyVaule, sliceToArray, mapToKeyValueList,
+// spanEventSliceToSpanEvents, spanLinkSlickToSpanLinks).
+func TestConvertTracesInput_RichSpanPayload(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.SetName("rich")
+	span.SetTraceID(pcommon.TraceID([16]byte{1}))
+	span.SetSpanID(pcommon.SpanID([8]byte{2}))
+
+	ev := span.Events().AppendEmpty()
+	ev.SetName("evt")
+	ea := ev.Attributes()
+	ea.PutStr("s", "str")
+	ea.PutInt("i", 1)
+	ea.PutDouble("d", 2.5)
+	ea.PutBool("b", true)
+	ea.PutEmptyBytes("by").Append(1, 2)
+	ea.PutEmptySlice("sl").AppendEmpty().SetStr("x")
+	ea.PutEmptyMap("m").PutStr("mk", "mv")
+
+	link := span.Links().AppendEmpty()
+	link.SetTraceID(pcommon.TraceID([16]byte{3}))
+	link.Attributes().PutStr("lk", "lv")
+
+	ti, err := convertTracesInput(span, pcommon.NewResource(), "svc", map[string]string{}, "json")
+	require.NoError(t, err)
+	assert.NotEmpty(t, ti.Payload)
+	assert.Contains(t, ti.Payload, "evt")
+}
+
+func TestConvertTracesInput_UnsupportedPayloadType(t *testing.T) {
+	span := newTraces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	_, err := convertTracesInput(span, pcommon.NewResource(), "svc", map[string]string{}, "bogus")
+	require.Error(t, err)
+}
+
+func TestCovertDBPayloadType(t *testing.T) {
+	assert.Equal(t, int8(2), covertDBPayloadType("json"))
+	assert.Equal(t, int8(2), covertDBPayloadType("proto"))
+	assert.Equal(t, int8(2), covertDBPayloadType("anything"))
+}
+
+// --- push / orchestration paths via fakeConn -------------------------------
+
+func TestPushTraceData_SingleNode(t *testing.T) {
+	fc := &fakeConn{}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, tracePayloadType: "json"}
+
+	require.NoError(t, e.pushTraceData(context.Background(), newTraces()))
+
+	require.Len(t, fc.queries, 1)
+	assert.Contains(t, fc.queries[0], "INSERT INTO traces_input")
+	require.Len(t, fc.batches, 1)
+	assert.True(t, fc.batches[0].sent)
+	require.Len(t, fc.batches[0].appended, 1)
+	_, ok := fc.batches[0].appended[0].(*TraceInput)
+	assert.True(t, ok)
+}
+
+func TestPushTraceData_ClientSideTwoBatches(t *testing.T) {
+	fc := &fakeConn{}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, cluster: true, clientSide: true, tracePayloadType: "proto"}
+
+	require.NoError(t, e.pushTraceData(context.Background(), newTraces()))
+
+	// client-side prepares the tempo_traces + attrs_gin batches
+	require.Len(t, fc.queries, 2)
+	assert.Contains(t, strings.Join(fc.queries, "\n"), "tempo_traces")
+	assert.Contains(t, strings.Join(fc.queries, "\n"), "tempo_traces_attrs_gin")
+	require.Len(t, fc.batches, 2)
+	assert.True(t, fc.batches[0].sent)
+	assert.True(t, fc.batches[1].sent)
+	// span converted into a TempoTrace on the main batch
+	require.NotEmpty(t, fc.batches[0].appended)
+	_, ok := fc.batches[0].appended[0].(*TempoTrace)
+	assert.True(t, ok)
+}
+
+func TestPushTraceData_PrepareBatchError(t *testing.T) {
+	fc := &fakeConn{prepareErr: errFakePrepare}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, tracePayloadType: "json"}
+
+	err := e.pushTraceData(context.Background(), newTraces())
+	require.ErrorIs(t, err, errFakePrepare)
+}
+
+func TestPushTraceData_SendError(t *testing.T) {
+	fc := &fakeConn{sendErr: errFakeSend}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, tracePayloadType: "json"}
+
+	err := e.pushTraceData(context.Background(), newTraces())
+	require.ErrorIs(t, err, errFakeSend)
+}
+
+func TestPushTraceData_AppendErrorAborts(t *testing.T) {
+	fc := &fakeConn{appendErr: errFakeAppend}
+	e := &tracesExporter{logger: zap.NewNop(), db: fc, tracePayloadType: "json"}
+
+	err := e.pushTraceData(context.Background(), newTraces())
+	require.ErrorIs(t, err, errFakeAppend)
+	require.Len(t, fc.batches, 1)
+	assert.True(t, fc.batches[0].aborted)
+}
+
+func TestExportResourceSpans_MissingClusterFlagErrors(t *testing.T) {
+	e := &tracesExporter{logger: zap.NewNop(), db: &fakeConn{}}
+	// bare context: the cluster flag guard must fire before touching the conn
+	err := e.exportResourceSapns(context.Background(), newTraces().ResourceSpans())
+	require.Error(t, err)
+}
+
+func TestTracesShutdownClosesConn(t *testing.T) {
+	fc := &fakeConn{}
+	e := &tracesExporter{db: fc}
+	require.NoError(t, e.Shutdown(context.Background()))
+	assert.True(t, fc.closed)
+}


### PR DESCRIPTION
## What

Raises `exporter/gigapipeexporter` statement coverage from **24% to 87%** (contrib acceptance bar is 80%), as part of preparing the exporter for donation to `opentelemetry-collector-contrib`.

The suite uses **in-memory fakes** — no ClickHouse, no Docker — so it runs in normal CI.

## Production change (one, behaviour-neutral)

A narrow testing seam in a new `db.go`:

```go
type chConn interface {
    PrepareBatch(ctx context.Context, query string, opts ...driver.PrepareBatchOption) (driver.Batch, error)
    Close() error
}
```

These are the only two `clickhouse.Conn` methods the exporters call (verified against every call site). `*clickhouse.Conn` returned by `clickhouse.Open` already satisfies `chConn`, so wiring and runtime behaviour are unchanged — the `db` fields in the logs/metrics/traces exporters and the `batchSamplesAndTimeSeries` parameter are retyped so tests can inject a fake.

## Tests added

- `testsupport_test.go` — fake `chConn` + `driver.Batch` + pdata fixtures.
- `traces_test.go`, `metrics_test.go`, `logs_push_test.go` — push paths and error propagation via the fakes; pure conversion helpers.
- `schema_test.go` — SQL builders (cluster vs single node).
- `trace_batch_processor_test.go` — `unhexAndPad` + trace/tags batch split.
- `factory_test.go` — extended to exercise all three create funcs (constructors + `initMetrics`).
- `schema_contract_test.go` — characterization tests pinning the Gigapipe polyglot schema (fingerprint join, Prometheus read model, Tempo two-table split, Loki label promotion) that distinguishes this exporter from the generic `clickhouseexporter`.

## Docs

- README gains a **Schema model** section explaining the schema and when to choose this exporter vs `clickhouseexporter`.
- New `docs/schema.md` deep-dive, cross-referencing the contract tests.

## Verification

- `go test ./exporter/gigapipeexporter/` — pass, **87.1%** coverage.
- `go vet` — clean; `gofmt` — clean.
- `go build ./cmd/otel-collector/` — succeeds (real `clickhouse.Conn` still satisfies `chConn`).

An optional build-tagged ClickHouse integration test is deferred (does not affect the unit-coverage bar).